### PR TITLE
Refine teleport level with moving hazards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1032,6 +1032,49 @@
             // Static purple block near the center
             { x: 0.49, y: 0.75, w: 0.02, h: 0.25 }
           ]
+        },
+        {
+          // -------------------------------------------------
+          // NEW LEVEL: Stage 2 Level 4 (index 22)
+          // -------------------------------------------------
+          spawn:  { x: 0.1, y: 0.83 },  // Start just above the first platform
+          target: { x: 0.9, y: 0.1 },   // Target near top-right
+          teleportLevel: true,
+          stage: 2,
+          platforms: [
+            { x: 0.0,  y: 0.85, w: 0.45, h: 0.02 },
+            { x: 0.55, y: 0.65, w: 0.45, h: 0.02 },
+            { x: 0.0,  y: 0.45, w: 0.45, h: 0.02 },
+            { x: 0.55, y: 0.25, w: 0.45, h: 0.02 }
+          ],
+          hazards: [
+            // Horizontal red block moving back and forth near the start
+            { x: 0.05, y: 0.78, w: 0.15, h: 0.02, dx: 0.4, moving: true },
+            // Vertical red block oscillating on the right side
+            { x: 0.72, y: 0.3, w: 0.08, h: 0.02, dy: 0.4, moving: true, verticalMovement: true }
+          ],
+          oranges: [],
+          browns: [],
+          purples: [
+            {
+              x: 0.48,
+              y: 0.0,
+              w: 0.04,
+              h: 0.4,
+              dy: 0.7,
+              moving: true,
+              verticalMovement: true
+            },
+            {
+              x: 0.48,
+              y: 0.6,
+              w: 0.04,
+              h: 0.4,
+              dy: -0.7,
+              moving: true,
+              verticalMovement: true
+            }
+          ]
         }
       ];
 
@@ -1149,12 +1192,16 @@
           width: p.w * canvas.width,
           height: p.h * canvas.height
         }));
-        // Map hazard definitions
+        // Map hazard definitions (support optional movement)
         hazards = (lvl.hazards || []).map(h => ({
           x: h.x * canvas.width,
           y: h.y * canvas.height,
           width: h.w * canvas.width,
-          height: h.h * canvas.height
+          height: h.h * canvas.height,
+          dx: h.dx || 0,
+          dy: h.dy || 0,
+          moving: h.moving || false,
+          verticalMovement: h.verticalMovement || false
         }));
         // Map orange (moving obstacles) definitions
         oranges = (lvl.oranges || []).map(o => ({
@@ -1200,6 +1247,17 @@
             h.maxX = canvas.width - h.width;
           });
         }
+
+        // Scale dx/dy for custom moving hazards
+        hazards.forEach(h => {
+          if (h.moving) {
+            if (h.verticalMovement) {
+              h.dy = applyGlobalMovementScale(h.dy);
+            } else {
+              h.dx = applyGlobalMovementScale(h.dx);
+            }
+          }
+        });
 
         // IMPORTANT: Scale dx/dy for all moving oranges/purples EXCEPT
         // level 9's oranges (since that’s already using currentOrangeDx).
@@ -1275,7 +1333,11 @@
           x: h.x * canvas.width,
           y: h.y * canvas.height,
           width: h.w * canvas.width,
-          height: h.h * canvas.height
+          height: h.h * canvas.height,
+          dx: h.dx || 0,
+          dy: h.dy || 0,
+          moving: h.moving || false,
+          verticalMovement: h.verticalMovement || false
         }));
         oranges = (lvl.oranges || []).map(o => ({
           x: o.x * canvas.width,
@@ -1311,6 +1373,17 @@
             h.maxX = canvas.width - h.width;
           });
         }
+
+        // Scale dx/dy for custom moving hazards
+        hazards.forEach(h => {
+          if (h.moving) {
+            if (h.verticalMovement) {
+              h.dy = applyGlobalMovementScale(h.dy);
+            } else {
+              h.dx = applyGlobalMovementScale(h.dx);
+            }
+          }
+        });
         oranges.forEach(o => {
           if (o.moving && currentLevel !== 9) {
             o.dx = applyGlobalMovementScale(o.dx);
@@ -1749,6 +1822,31 @@
             }
           });
         }
+
+        // Move hazards defined with custom movement
+        hazards.forEach(h => {
+          if (h.moving) {
+            if (h.verticalMovement) {
+              h.y += h.dy;
+              if (h.y < 0) {
+                h.y = 0;
+                h.dy = -h.dy;
+              } else if (h.y + h.height > canvas.height) {
+                h.y = canvas.height - h.height;
+                h.dy = -h.dy;
+              }
+            } else {
+              h.x += h.dx;
+              if (h.x < 0) {
+                h.x = 0;
+                h.dx = -h.dx;
+              } else if (h.x + h.width > canvas.width) {
+                h.x = canvas.width - h.width;
+                h.dx = -h.dx;
+              }
+            }
+          }
+        });
 
         // -------------------------------
         // REWORKED MOVEMENT FOR ORANGES & PURPLES


### PR DESCRIPTION
## Summary
- fix Stage 2 Level 4 spawn position so player doesn't start inside a platform
- add moving red hazards to Stage 2 Level 4 for a moderate challenge
- extend engine to support moving hazards via dx/dy definitions

## Testing
- `git status --short`