### PR TITLE
Fix Stage2 Level5 beam width

### DIFF
--- a/index.html
+++ b/index.html
@@ -1092,7 +1092,8 @@
 
           // overhead grey beam: y=820px, height=80px
           platforms: [
-            { x: 0,            y: 820/1080, w: 1,        h: 80/1080 }
+            // shortened so it stops at the purple wall on the right
+            { x: 0,            y: 820/1080, w: 500/1920, h: 80/1080 }
           ],
 
           // kill-strips exactly 22px tall on top/bottom, 38px wide on left/right


### PR DESCRIPTION
## Summary
- shorten Stage 2 Level 5's overhead beam so it ends at the purple wall

## Testing
- `npm test` *(fails: package.json not found)*