### PR TITLE
Fix Stage 2-5 beam position

### DIFF
--- a/index.html
+++ b/index.html
@@ -1092,8 +1092,8 @@
 
           // overhead grey beam: y=820px, height=80px
           platforms: [
-            // shortened so it stops at the purple wall on the right
-            { x: 0,            y: 820/1080, w: 500/1920, h: 80/1080 }
+            // right half only from purple wall to kill strip
+            { x: 580/1920,    y: 820/1080, w: 1302/1920, h: 80/1080 }
           ],
 
           // kill-strips exactly 22px tall on top/bottom, 38px wide on left/right


### PR DESCRIPTION
## Summary
- adjust Stage 2 Level 5 beam location so it starts after the purple wall and ends before the kill strip

## Testing
- `git status --short`