### PR TITLE
Update Stage 2 Level 6 lift movement

### DIFF
--- a/index.html
+++ b/index.html
@@ -1182,13 +1182,15 @@
           lifts: [
             {
               // just to the right of the red left-border kill strip
+              // spawns 15% of the screen height above the player’s start
               x: 60/1920,
-              y: 650/1080,
+              y: 788/1080,
               w: 20/1920,
-              h: 260/1080,
+              h: 260/1080, // unchanged height
               dy: -2,
-              minY: 300/1080,
-              maxY: 650/1080
+              // travels up toward the mid-screen shelf then returns
+              minY: 220/1080,
+              maxY: 788/1080
             }
           ]
         }


### PR DESCRIPTION
## Summary
- adjust the far-left lift on Stage 2 – Level 6 so it spawns at `y=788px`
- extend its travel range to `minY=220px` and allow it to return to the start

## Testing
- `npm test` *(fails: `package.json` not found)*