### PR TITLE
Add Stage 2 Level 7 with new hazard mechanics

### DIFF
--- a/index.html
+++ b/index.html
@@ -1193,6 +1193,50 @@
               maxY: 788/1080
             }
           ]
+        },
+        {
+          // -------------------------------------------------
+          // NEW LEVEL: Stage 2 - Level 7  (index 25)
+          // -------------------------------------------------
+          spawn:  { x: 150/1920,  y: 950/1080 },
+          target: { x: 1750/1920, y: 100/1080 },
+
+          teleportLevel: true,
+          stage: 2,
+
+          // Solid grey platforms including a teleport-blocking pillar
+          platforms: [
+            { x: 400/1920,  y: 300/1080, w: 500/1920, h: 20/1080 },
+            { x: 900/1920,  y: 780/1080, w: 500/1920, h: 20/1080 },
+            { x: 1400/1920, y: 350/1080, w: 500/1920, h: 20/1080 },
+            { x: 1650/1920, y: 370/1080, w: 30/1920, h: 710/1080 }
+          ],
+
+          hazards: [
+            // Vertically moving hazards
+            { x: 650/1920,  y: 320/1080, w: 50/1920, h: 200/1080,
+              dy: 1.8, moving: true, verticalMovement: true,
+              minY: 320/1080, maxY: 700/1080 },
+            { x: 1150/1920, y:   0/1080, w: 50/1920, h: 250/1080,
+              dy: 2.2, moving: true, verticalMovement: true,
+              minY:   0/1080, maxY: 550/1080 },
+
+            // Horizontally moving hazard
+            { x: 1400/1920, y: 700/1080, w: 200/1920, h: 50/1080,
+              dx: 2, moving: true,
+              minX: 1000/1920, maxX: 1600/1920 },
+
+            // Stationary hazard guarding the target
+            { x: 1500/1920, y: 200/1080, w: 150/1920, h: 30/1080 }
+          ],
+
+          oranges: [],
+          browns: [],
+          purples: [
+            { x: 400/1920,  y: 300/1080, w: 20/1920,  h: 780/1080 },
+            { x: 900/1920,  y:   0/1080, w: 20/1920,  h: 780/1080 },
+            { x: 1400/1920, y: 350/1080, w: 20/1920,  h: 730/1080 }
+          ]
         }
       ];
 
@@ -1325,8 +1369,14 @@
           width: h.w * canvas.width,
           height: h.h * canvas.height,
           dy: h.dy || 0,
+          dx: h.dx || 0,
+          vx: h.vx || 0,
           moving: h.moving || false,
-          verticalMovement: h.verticalMovement || false
+          verticalMovement: h.verticalMovement || false,
+          minX: (h.minX !== undefined ? h.minX : 0) * canvas.width,
+          maxX: (h.maxX !== undefined ? h.maxX : 1) * canvas.width,
+          minY: (h.minY !== undefined ? h.minY : 0) * canvas.height,
+          maxY: (h.maxY !== undefined ? h.maxY : 1) * canvas.height
         }));
         // Map orange (moving obstacles) definitions
         oranges = (lvl.oranges || []).map(o => ({
@@ -1389,6 +1439,9 @@
         hazards.forEach(h => {
           if (h.verticalMovement) {
             h.dy = applyGlobalMovementScale(h.dy);
+          }
+          if (h.dx) {
+            h.dx = applyGlobalMovementScale(h.dx);
           }
         });
 
@@ -1474,8 +1527,14 @@
           width: h.w * canvas.width,
           height: h.h * canvas.height,
           dy: h.dy || 0,
+          dx: h.dx || 0,
+          vx: h.vx || 0,
           moving: h.moving || false,
-          verticalMovement: h.verticalMovement || false
+          verticalMovement: h.verticalMovement || false,
+          minX: (h.minX !== undefined ? h.minX : 0) * canvas.width,
+          maxX: (h.maxX !== undefined ? h.maxX : 1) * canvas.width,
+          minY: (h.minY !== undefined ? h.minY : 0) * canvas.height,
+          maxY: (h.maxY !== undefined ? h.maxY : 1) * canvas.height
         }));
         oranges = (lvl.oranges || []).map(o => ({
           x: o.x * canvas.width,
@@ -1516,6 +1575,9 @@
         hazards.forEach(h => {
           if (h.verticalMovement) {
             h.dy = applyGlobalMovementScale(h.dy);
+          }
+          if (h.dx) {
+            h.dx = applyGlobalMovementScale(h.dx);
           }
         });
         oranges.forEach(o => {
@@ -1956,22 +2018,40 @@
         if ([2, 3, 4, 5, 6, 21].includes(currentLevel)) {
           hazards.forEach(h => {
             h.x += h.vx;
-            if (h.x < h.minX || h.x > canvas.width) {
+            if (h.x < h.minX || h.x > h.maxX) {
               h.vx = -h.vx;
             }
           });
         }
 
-        // Handle vertically moving hazards
+        // Additional horizontal hazard movement using custom dx/minX/maxX
+        hazards.forEach(h => {
+          if (h.dx) {
+            h.x += h.dx;
+            const minX = h.minX || 0;
+            const maxX = h.maxX || canvas.width;
+            if (h.x < minX) {
+              h.x = minX;
+              h.dx = Math.abs(h.dx);
+            } else if (h.x + h.width > maxX) {
+              h.x = maxX - h.width;
+              h.dx = -Math.abs(h.dx);
+            }
+          }
+        });
+
+        // Handle vertically moving hazards with optional bounds
         hazards.forEach(h => {
           if (h.moving && h.verticalMovement) {
             h.y += h.dy;
-            if (h.y < 0) {
-              h.y = 0;
-              h.dy = -h.dy;
-            } else if (h.y + h.height > canvas.height) {
-              h.y = canvas.height - h.height;
-              h.dy = -h.dy;
+            const minY = h.minY || 0;
+            const maxY = h.maxY || canvas.height;
+            if (h.y < minY) {
+              h.y = minY;
+              h.dy = Math.abs(h.dy);
+            } else if (h.y + h.height > maxY) {
+              h.y = maxY - h.height;
+              h.dy = -Math.abs(h.dy);
             }
           }
         });

--- a/index.html
+++ b/index.html
@@ -1216,7 +1216,7 @@
             // Vertically moving hazards
             { x: 650/1920,  y: 320/1080, w: 50/1920, h: 200/1080,
               dy: 1.8, moving: true, verticalMovement: true,
-              minY: 320/1080, maxY: 700/1080 },
+              minY: 320/1080, maxY: 900/1080 },
             { x: 1150/1920, y:   0/1080, w: 50/1920, h: 250/1080,
               dy: 2.2, moving: true, verticalMovement: true,
               minY:   0/1080, maxY: 550/1080 },


### PR DESCRIPTION
## Summary
- add Stage 2 Level 7 definition
- extend hazard mapping to support dx and movement bounds
- scale horizontal hazard speeds
- update game loop to handle bounded hazard movement

## Testing
- `git status --short`
