### PR TITLE
Modify Stage 2 Level 8 layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1249,7 +1249,38 @@
           teleportLevel: true,
           stage: 2,
 
-          platforms: [],
+          platforms: [
+            // Small blocks replacing previous grey lines
+            { x: 0.25, y: 0.45, w: 0.02, h: 0.02 },
+            { x: 0.25, y: 0.50, w: 0.02, h: 0.02 },
+            { x: 0.25, y: 0.55, w: 0.02, h: 0.02 },
+            { x: 0.25, y: 0.60, w: 0.02, h: 0.02 },
+            { x: 0.25, y: 0.65, w: 0.02, h: 0.02 },
+
+            { x: 0.50, y: 0.35, w: 0.02, h: 0.02 },
+            { x: 0.50, y: 0.40, w: 0.02, h: 0.02 },
+            { x: 0.50, y: 0.45, w: 0.02, h: 0.02 },
+            { x: 0.50, y: 0.50, w: 0.02, h: 0.02 },
+            { x: 0.50, y: 0.55, w: 0.02, h: 0.02 },
+
+            { x: 0.75, y: 0.45, w: 0.02, h: 0.02 },
+            { x: 0.75, y: 0.50, w: 0.02, h: 0.02 },
+            { x: 0.75, y: 0.55, w: 0.02, h: 0.02 },
+            { x: 0.75, y: 0.60, w: 0.02, h: 0.02 },
+            { x: 0.75, y: 0.65, w: 0.02, h: 0.02 },
+
+            { x: 0.10, y: 0.60, w: 0.02, h: 0.02 },
+            { x: 0.15, y: 0.60, w: 0.02, h: 0.02 },
+            { x: 0.20, y: 0.60, w: 0.02, h: 0.02 },
+            { x: 0.25, y: 0.60, w: 0.02, h: 0.02 },
+            { x: 0.30, y: 0.60, w: 0.02, h: 0.02 },
+
+            { x: 0.55, y: 0.50, w: 0.02, h: 0.02 },
+            { x: 0.60, y: 0.50, w: 0.02, h: 0.02 },
+            { x: 0.65, y: 0.50, w: 0.02, h: 0.02 },
+            { x: 0.70, y: 0.50, w: 0.02, h: 0.02 },
+            { x: 0.75, y: 0.50, w: 0.02, h: 0.02 }
+          ],
 
           hazards: [
             // Bottom zone: horizontally moving pair
@@ -1270,20 +1301,17 @@
               minY: 0.05, maxY: 0.30 },
             { x: 0.75, y: 0.20, w: 0.05, h: 0.15,
               dy: -1.2, moving: true, verticalMovement: true,
-              minY: 0.05, maxY: 0.30 }
+              minY: 0.05, maxY: 0.30 },
+
+            // Static hazard just left of the target
+            { x: 0.47, y: 0.00, w: 0.02, h: 0.10 }
           ],
 
           oranges: [],
           browns: [],
 
-          purples: [
-            // Middle zone maze walls creating narrow passages
-            { x: 0.25, y: 0.45, w: 0.02, h: 0.25 },
-            { x: 0.50, y: 0.35, w: 0.02, h: 0.25 },
-            { x: 0.75, y: 0.45, w: 0.02, h: 0.25 },
-            { x: 0.10, y: 0.60, w: 0.25, h: 0.02 },
-            { x: 0.55, y: 0.50, w: 0.25, h: 0.02 }
-          ]
+          // Old grey lines replaced by blocks in the platforms array
+          purples: []
         }
       ];
 


### PR DESCRIPTION
## Summary
- replace teleport maze lines with small grey blocks in Stage 2 Level 8
- add a stationary hazard to the left of the goal cube

## Testing
- `npm test` *(fails: `package.json` not found)*
- `pytest` *(fails: command not found)*