### PR TITLE
Adjust stage 2 level 11 purple wall speed

### DIFF
--- a/index.html
+++ b/index.html
@@ -1337,7 +1337,7 @@
           browns: [],
           purples: [
             // NEW: Moving vertical purple wall that traverses the level
-            { x: 0.98, y: 0, w: 0.02, h: 1, dx: -2, moving: true }
+            { x: 0.98, y: 0, w: 0.02, h: 1, dx: -1.2, moving: true }
           ],
           lifts: [
             // Former red hazards are now harmless grey lifts


### PR DESCRIPTION
## Summary
- slow down the moving purple wall in Stage 2 Level 11 by 40%

## Testing
- `git log -1 --stat`