### PR TITLE
Update Stage 2 level 12 blue blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1378,9 +1378,12 @@
             { x: 0.3, y: 0,    w: 0.02, h: 1 }
           ],
           blues: [
-            { x: 0.04, y: 0.15, w: 0.05, h: 0.02, moving: true, dx: 0.45, minX: 0, maxX: 0.25 },
-            { x: 0.11, y: 0.30, w: 0.05, h: 0.02, moving: true, dx: 0.45, minX: 0, maxX: 0.25 },
-            { x: 0.18, y: 0.45, w: 0.05, h: 0.02, moving: true, dx: 0.45, minX: 0, maxX: 0.25 }
+            // Top block - fastest
+            { x: 0.04, y: 0.15, w: 0.05, h: 0.02, moving: true, dx: 0.7,  minX: 0, maxX: 0.3 },
+            // Middle block - medium speed
+            { x: 0.11, y: 0.30, w: 0.05, h: 0.02, moving: true, dx: 0.55, minX: 0, maxX: 0.3 },
+            // Bottom block - original speed
+            { x: 0.18, y: 0.45, w: 0.05, h: 0.02, moving: true, dx: 0.45, minX: 0, maxX: 0.3 }
           ]
         }
       ];


### PR DESCRIPTION
## Summary
- extend horizontal travel distance of Stage 2 level 12 blue blocks so they touch the purple wall
- vary each block's speed so the top is fastest and middle is medium speed

## Testing
- `npm test` *(fails: Could not read package.json)*