### PR TITLE
Fix Stage 2 Level 12 blue block spawn positions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1378,12 +1378,12 @@
             { x: 0.3, y: 0,    w: 0.02, h: 1 }
           ],
           blues: [
-            // Top block - fastest
-            { x: 0.04, y: 0.15, w: 0.05, h: 0.02, moving: true, dx: 0.7,  minX: 0, maxX: 0.3 },
-            // Middle block - medium speed
-            { x: 0.11, y: 0.30, w: 0.05, h: 0.02, moving: true, dx: 0.55, minX: 0, maxX: 0.3 },
-            // Bottom block - original speed
-            { x: 0.18, y: 0.45, w: 0.05, h: 0.02, moving: true, dx: 0.45, minX: 0, maxX: 0.3 }
+            // Top block - fastest (spawns on the left)
+            { x: 0.04,  y: 0.15, w: 0.05, h: 0.02, moving: true, dx: 0.7,  minX: 0,    maxX: 0.3 },
+            // Middle block - medium speed (spawns in the center)
+            { x: 0.475, y: 0.30, w: 0.05, h: 0.02, moving: true, dx: 0.55, minX: 0.35, maxX: 0.65 },
+            // Bottom block - original speed (spawns on the right)
+            { x: 0.90,  y: 0.45, w: 0.05, h: 0.02, moving: true, dx: 0.45, minX: 0.7,  maxX: 1 }
           ]
         }
       ];


### PR DESCRIPTION
## Summary
- move Stage 2 Level 12 moving blue blocks so they start left, center and right

## Testing
- `git status --short`