### PR TITLE
Fix teleport challenge red block collision

### DIFF
--- a/index.html
+++ b/index.html
@@ -2153,9 +2153,6 @@
         if (gamePaused) return;
         const now = Date.now();
         let obstacles = [...platforms, ...browns, ...lifts];
-        if (levels[currentLevel].challengeTeleportLevel) {
-          obstacles = obstacles.concat(challengeGreyBlocks);
-        }
         if (levels[currentLevel].fallingBrownLevel) {
           obstacles = obstacles.concat(fallingBrownBlocks);
         }


### PR DESCRIPTION
## Summary
- ensure red blocks in teleportation challenge kill on side contact by removing them from obstacle checks

## Testing
- `git status --short`