### PR TITLE
Fix teleport challenge freeze

### DIFF
--- a/index.html
+++ b/index.html
@@ -1548,6 +1548,7 @@
             challengeGreyBlocks = [];
             challengeWhiteBlock = null;
             fallingRedBlocks = [];
+            pendingBlueLines = [];
             fallingRedTextStart = Date.now();
             lastRedSpawnTime = Date.now();
             if (index === 30 && teleportCheckpoint) {
@@ -3215,6 +3216,7 @@
                 lastTeleportLineSpawn = challengeStartTime;
                 lastGreyBlockSpawn = challengeStartTime;
                 lastComboSpawn = challengeStartTime;
+                pendingBlueLines = [];
               }
           }
           if (challengePhase === 3 && challengeGreenBlock) {


### PR DESCRIPTION
## Summary
- reinitialize pending blue line spawns when loading the teleport challenge
- clear pending blue line spawns when reaching a checkpoint

## Testing
- `npm --version`