### PR TITLE
Update teleport combo spawning

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,7 +480,6 @@
 
       // Additional globals for the teleport challenge (Stage 2 Level 13)
       let challengeTeleportLines = [];
-      let lastTeleportLineSpawn = 0;
       let challengeGreyBlocks = [];
       let lastGreyBlockSpawn = 0;
       let challengeGreyBlockSpeed = 1;
@@ -1539,7 +1538,6 @@
         } else if (lvl.challengeTeleportLevel) {
             target = null;
             challengeStartTime = Date.now();
-            lastTeleportLineSpawn = Date.now();
             lastGreyBlockSpawn = Date.now();
             challengeTeleportLines = [];
             challengeGreyBlocks = [];
@@ -2929,21 +2927,17 @@
           }
 
           let elapsed = (now - challengeStartTime) - challengePausedTime;
-          let remaining = challengeDuration - elapsed;
 
             let spawnInterval;
-            if (challengePhase === 3) {
-              spawnInterval = currentMode === "hard" ? 3000 : currentMode === "easy" ? 6000 : 5000;
-            } else if (remaining > 20000) {
-              spawnInterval = currentMode === "easy" ? 5000 : currentMode === "hard" ? 3000 : 4000;
-            } else if (remaining > 10000) {
-              spawnInterval = currentMode === "easy" ? 4000 : currentMode === "hard" ? 2000 : 3000;
+            if (challengePhase === 1) {
+              spawnInterval = currentMode === "hard" ? 5000 : currentMode === "easy" ? 9000 : 7000;
+            } else if (challengePhase === 2) {
+              spawnInterval = currentMode === "hard" ? 4000 : currentMode === "easy" ? 6000 : 5000;
             } else {
-              spawnInterval = currentMode === "easy" ? 3000 : currentMode === "hard" ? 1000 : 2000;
+              spawnInterval = currentMode === "hard" ? 3000 : currentMode === "easy" ? 5000 : 4000;
             }
 
-            if (challengePhase === 3) {
-              if (now - lastComboSpawn >= spawnInterval) {
+            if (now - lastComboSpawn >= spawnInterval) {
                 let sides = ["top", "bottom", "left", "right"];
                 let side = sides[Math.floor(Math.random() * sides.length)];
                 let orientation = (side === "top" || side === "bottom") ? "horizontal" : "vertical";
@@ -2972,8 +2966,8 @@
                   pendingBlueLines.push({ side, orientation, spawnTime: now + 500 });
                   lastComboSpawn = now;
                 }
-              }
-              for (let i = pendingBlueLines.length - 1; i >= 0; i--) {
+            }
+            for (let i = pendingBlueLines.length - 1; i >= 0; i--) {
                 if (now >= pendingBlueLines[i].spawnTime) {
                   let p = pendingBlueLines[i];
                   let thickness = 20;
@@ -2993,70 +2987,6 @@
                   }
                   pendingBlueLines.splice(i,1);
                 }
-              }
-            } else if (now - lastTeleportLineSpawn >= spawnInterval) {
-            let sides = ["top", "bottom", "left", "right"];
-            let side = sides[Math.floor(Math.random() * sides.length)];
-            let thickness = 20;
-            let color = Math.random() < 0.5 ? "purple" : "blue";
-            let orientation = (side === "top" || side === "bottom") ? "horizontal" : "vertical";
-
-            if (color === "blue" && (
-                (side === "top" || side === "bottom") ?
-                  (activeBlueSides.top || activeBlueSides.bottom) :
-                  (activeBlueSides.left || activeBlueSides.right)
-              )) {
-              // Skip spawning another blue line on the same axis
-            } else if (color === "purple" && activePurpleAxes[orientation]) {
-              // Skip spawning another purple line on the same axis
-            } else {
-              if (color === "purple") {
-                let obj = { x: 0, y: 0, width: 0, height: 0 };
-                const speed = challengeLineSpeed * purpleLineSpeedFactor;
-                if (side === "top") {
-                  obj.x = 0;
-                  obj.y = -thickness;
-                  obj.width = canvas.width;
-                  obj.height = thickness;
-                  challengeTeleportLines.push({ obj, vx: 0, vy: speed, color, side });
-                } else if (side === "bottom") {
-                  obj.x = 0;
-                  obj.y = canvas.height;
-                  obj.width = canvas.width;
-                  obj.height = thickness;
-                  challengeTeleportLines.push({ obj, vx: 0, vy: -speed, color, side });
-                } else if (side === "left") {
-                  obj.x = -thickness;
-                  obj.y = 0;
-                  obj.width = thickness;
-                  obj.height = canvas.height;
-                  challengeTeleportLines.push({ obj, vx: speed, vy: 0, color, side });
-                } else if (side === "right") {
-                  obj.x = canvas.width;
-                  obj.y = 0;
-                  obj.width = thickness;
-                  obj.height = canvas.height;
-                  challengeTeleportLines.push({ obj, vx: -speed, vy: 0, color, side });
-                }
-                purples.push(obj);
-                activePurpleAxes[orientation] = true;
-              } else {
-                activeBlueSides[side] = true;
-                if (side === "top" || side === "bottom") {
-                  let holeX = Math.random() * (canvas.width - teleportBlueHoleSize);
-                  let seg1 = { x: 0, y: (side === "top" ? -thickness : canvas.height), width: holeX, height: thickness };
-                  let seg2 = { x: holeX + teleportBlueHoleSize, y: (side === "top" ? -thickness : canvas.height), width: canvas.width - (holeX + teleportBlueHoleSize), height: thickness };
-                  challengeTeleportLines.push({ segments: [seg1, seg2], vx: 0, vy: (side === "top" ? challengeLineSpeed : -challengeLineSpeed), color, side });
-                  blues.push(seg1, seg2);
-                } else {
-                  let holeY = Math.random() * (canvas.height - teleportBlueHoleSize);
-                  let seg1 = { x: (side === "left" ? -thickness : canvas.width), y: 0, width: thickness, height: holeY };
-                  let seg2 = { x: (side === "left" ? -thickness : canvas.width), y: holeY + teleportBlueHoleSize, width: thickness, height: canvas.height - (holeY + teleportBlueHoleSize) };
-                  challengeTeleportLines.push({ segments: [seg1, seg2], vx: (side === "left" ? challengeLineSpeed : -challengeLineSpeed), vy: 0, color, side });
-                  blues.push(seg1, seg2);
-                }
-              }
-              lastTeleportLineSpawn = now;
             }
           }
 
@@ -3203,7 +3133,6 @@
                     document.getElementById("checkpointPopup").classList.add("hidden");
                 }, 5000);
                 challengeStartTime = Date.now();
-                lastTeleportLineSpawn = challengeStartTime;
                 lastGreyBlockSpawn = challengeStartTime;
                 lastComboSpawn = challengeStartTime;
               }


### PR DESCRIPTION
## Summary
- adjust teleport challenge to spawn purple/blue combos in all phases
- use constant spawn intervals per phase
- remove single-line spawn logic and old timer
- reset `lastComboSpawn` on level start and checkpoints

## Testing
- `git status --short`