### PR TITLE
Add Stage 3 Level 5

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,6 +558,15 @@
       let stage3Level4LineSpeed = baseStage3Level4LineSpeed;
       const baseStage3Level4SpawnInterval = 825;
       let stage3Level4SpawnInterval = baseStage3Level4SpawnInterval;
+
+      // Variables for Stage 3 Level 5
+      const stage3Level5SegmentCount = 11;
+      const stage3Level5RadiusRatio = 0.35;
+      const stage3Level5LineLengthRatio = 0.6;
+      const stage3Level5LineHeightRatio = 0.02;
+      let stage3Level5Angle = 0;
+      const baseStage3Level5AngularSpeed = 0.02;
+      let stage3Level5AngularSpeed = baseStage3Level5AngularSpeed;
       // =====================================================================
 
       // -------------------------------------------------
@@ -1562,6 +1571,19 @@
           stage3Level4: true,
           platforms: [],
           hazards: []
+        },
+        {
+          // -------------------------------------------------
+          // NEW LEVEL: Stage 3 - Level 5 (index 35)
+          // Orbiting striped line hazard
+          // -------------------------------------------------
+          spawn: { x: 0.05, y: 0.95 },
+          target: { x: 0.95, y: 0.05 },
+          colorLevel: true,
+          stage: 3,
+          stage3Level5: true,
+          platforms: [],
+          hazards: []
         }
       ];
 
@@ -1745,6 +1767,15 @@
           target = {
             x: stage3Level4TargetPositions[0].x * canvas.width,
             y: stage3Level4TargetPositions[0].y * canvas.height,
+            size: cube.size
+          };
+        } else if (lvl.stage3Level5) {
+          stage3Level5Angle = 0;
+          stage3Level5AngularSpeed =
+            baseStage3Level5AngularSpeed * (currentMode === "easy" ? 0.6 : currentMode === "hard" ? 1.2 : 1);
+          target = {
+            x: lvl.target.x * canvas.width,
+            y: lvl.target.y * canvas.height,
             size: cube.size
           };
         } else if (lvl.fallingBrownLevel) {
@@ -2747,6 +2778,10 @@
           }
         }
 
+        if (levels[currentLevel].stage3Level5) {
+          stage3Level5Angle -= stage3Level5AngularSpeed;
+        }
+
         if (levels[currentLevel].stage3Level4 && stage3Level4Triggered) {
           if (now - stage3Level4LastSpawn >= stage3Level4SpawnInterval) {
             const h = 0.02 * canvas.height;
@@ -2848,6 +2883,25 @@
             const lRect = { x: line.x, y: line.y, width: line.width, height: line.height };
             if (rectIntersect(cubeRect, lRect)) {
               if (outlineColor !== line.color) {
+                deathSound.currentTime = 0;
+                deathSound.play();
+                loadLevel(currentLevel);
+                return;
+              }
+            }
+          }
+        } else if (currentLevel === 35) {
+          const cx = canvas.width / 2 + stage3Level5RadiusRatio * Math.min(canvas.width, canvas.height) * Math.cos(stage3Level5Angle);
+          const cy = canvas.height / 2 + stage3Level5RadiusRatio * Math.min(canvas.width, canvas.height) * Math.sin(stage3Level5Angle);
+          const segW = stage3Level5LineLengthRatio * canvas.width / stage3Level5SegmentCount;
+          const segH = stage3Level5LineHeightRatio * canvas.height;
+          let startX = cx - (stage3Level5LineLengthRatio * canvas.width) / 2;
+          let startY = cy - segH / 2;
+          for (let i = 0; i < stage3Level5SegmentCount; i++) {
+            const color = i % 2 === 0 ? "cyan" : "yellow";
+            const segRect = { x: startX + i * segW, y: startY, width: segW, height: segH };
+            if (rectIntersect(cubeRect, segRect)) {
+              if (outlineColor !== color) {
                 deathSound.currentTime = 0;
                 deathSound.play();
                 loadLevel(currentLevel);
@@ -3559,6 +3613,21 @@
           }
         }
       }
+
+      function drawStage3Level5Line() {
+        if (currentLevel === 35) {
+          const cx = canvas.width / 2 + stage3Level5RadiusRatio * Math.min(canvas.width, canvas.height) * Math.cos(stage3Level5Angle);
+          const cy = canvas.height / 2 + stage3Level5RadiusRatio * Math.min(canvas.width, canvas.height) * Math.sin(stage3Level5Angle);
+          const segW = stage3Level5LineLengthRatio * canvas.width / stage3Level5SegmentCount;
+          const segH = stage3Level5LineHeightRatio * canvas.height;
+          let startX = cx - (stage3Level5LineLengthRatio * canvas.width) / 2;
+          let startY = cy - segH / 2;
+          for (let i = 0; i < stage3Level5SegmentCount; i++) {
+            ctx.fillStyle = i % 2 === 0 ? "cyan" : "yellow";
+            ctx.fillRect(startX + i * segW, startY, segW, segH);
+          }
+        }
+      }
       function drawBrowns() {
         ctx.fillStyle = "saddlebrown";
         for (let b of browns) {
@@ -3799,6 +3868,7 @@
       drawCyans();
       drawYellows();
       drawStage3Level4Lines();
+      drawStage3Level5Line();
       drawBlues();
       drawBrowns();
         drawLifts();


### PR DESCRIPTION
## Summary
- add new Stage 3 Level 5 with rotating cyan/yellow line hazard
- support Stage 3 Level 5 movement, drawing and collisions

## Testing
- `npm test` *(fails: Could not read package.json)*