### PR TITLE
Add Stage 3 Level 6

### DIFF
--- a/index.html
+++ b/index.html
@@ -1582,6 +1582,33 @@
           stage3Level5: true,
           platforms: [],
           hazards: []
+        },
+        {
+          // -------------------------------------------------
+          // NEW LEVEL: Stage 3 - Level 6 (index 36)
+          // Stage 1 Level 4 layout with rotating color obstacle
+          // -------------------------------------------------
+          spawn:  { x: 0.05, y: 0.1 },
+          target: { x: 0.95, y: 0.9 },
+          colorLevel: true,
+          stage: 3,
+          stage3Level5: true,
+          platforms: [
+            { x: 0.0, y: 0.0, w: 1.0, h: 0.02 },
+            { x: 0.0, y: 0.98, w: 1.0, h: 0.02 },
+            { x: 0, y: 594/1080, w: 40/1920, h: 160/1080 },
+            { x: 0.98, y: 0.0, w: 0.02, h: 1.0 },
+            { x: 0.1, y: 0.3, w: 0.6, h: 0.02 },
+            { x: 0.2, y: 0.6, w: 0.6, h: 0.02 },
+            { x: 0.5, y: 0.3, w: 0.02, h: 0.3 }
+          ],
+          hazards: [
+            { x: 0.25, y: 0.45, w: 0.05, h: 0.05 },
+            { x: 0.65, y: 0.55, w: 0.05, h: 0.05 },
+            { x: 0.40, y: 0.20, w: 0.05, h: 0.05 },
+            { x: 0.70, y: 0.75, w: 0.05, h: 0.05 },
+            { x: 0.15, y: 0.70, w: 0.05, h: 0.05 }
+          ]
         }
       ];
 
@@ -2910,7 +2937,7 @@
           }
         }
 
-        if (currentLevel === 35) {
+        if (levels[currentLevel].stage3Level5) {
           const pivotX = canvas.width / 2;
           const pivotY = canvas.height / 2;
           function rotPtGlobal(x, y, ang) {
@@ -3640,7 +3667,7 @@
       }
 
       function drawStage3Level5Line() {
-        if (currentLevel === 35) {
+        if (levels[currentLevel].stage3Level5) {
           const pivotX = canvas.width / 2;
           const pivotY = canvas.height / 2;
           ctx.save();


### PR DESCRIPTION
## Summary
- add Stage 3 level 6 using the layout from Stage 1 level 4
- reuse the rotating cyan/yellow line mechanic
- generalize Stage 3 level 5 checks so other levels can use the spinner

## Testing
- `npm test` *(fails: Could not read package.json)*