### PR TITLE
Add Stage 3 level 6

### DIFF
--- a/index.html
+++ b/index.html
@@ -1582,6 +1582,25 @@
           stage3Level5: true,
           platforms: [],
           hazards: []
+        },
+        {
+          // -------------------------------------------------
+          // NEW LEVEL: Stage 3 - Level 6 (index 36)
+          // Stage 1 Level 3 layout with rotating cyan/yellow line
+          // -------------------------------------------------
+          spawn: { x: 0.1, y: 0.95 },
+          target: { x: 0.9, y: 0.05 },
+          colorLevel: true,
+          stage: 3,
+          stage3Level5: true,
+          platforms: [
+            { x: 0.2, y: 0.7, w: 0.25, h: 0.03 },
+            { x: 0.55, y: 0.4, w: 0.3, h: 0.03 }
+          ],
+          hazards: [
+            { x: 0.4, y: 0.6, w: 0.1, h: 0.1 },
+            { x: 0.7, y: 0.3, w: 0.1, h: 0.1 }
+          ]
         }
       ];
 
@@ -2910,7 +2929,7 @@
           }
         }
 
-        if (currentLevel === 35) {
+        if (currentLevel === 35 || currentLevel === 36) {
           const pivotX = canvas.width / 2;
           const pivotY = canvas.height / 2;
           function rotPtGlobal(x, y, ang) {
@@ -3640,7 +3659,7 @@
       }
 
       function drawStage3Level5Line() {
-        if (currentLevel === 35) {
+        if (currentLevel === 35 || currentLevel === 36) {
           const pivotX = canvas.width / 2;
           const pivotY = canvas.height / 2;
           ctx.save();


### PR DESCRIPTION
## Summary
- add new Stage 3 Level 6 using Stage 1 Level 3 layout
- allow rotating cyan/yellow obstacle on level 36

## Testing
- `npm test` *(fails: could not find package.json)*