### PR TITLE
Add Stage 3 Level 6 with rotating block

### DIFF
--- a/index.html
+++ b/index.html
@@ -1582,6 +1582,28 @@
           stage3Level5: true,
           platforms: [],
           hazards: []
+        },
+        {
+          // -------------------------------------------------
+          // NEW LEVEL: Stage 3 - Level 6 (index 36)
+          // Classic platform layout with rotating cyan/yellow line obstacle
+          // -------------------------------------------------
+          spawn:  { x: 0.05, y: 0.95 },
+          target: { x: 0.95, y: 0.05 },
+          colorLevel: true,
+          stage: 3,
+          stage3Level5: true,
+          platforms: [
+            { x: 0.0, y: 0.8, w: 0.45, h: 0.02 },
+            { x: 0.7, y: 0.8, w: 0.3, h: 0.02 },
+            { x: 0.0, y: 0.6, w: 0.15, h: 0.02 },
+            { x: 0.35, y: 0.6, w: 0.65, h: 0.02 },
+            { x: 0.0, y: 0.4, w: 0.3, h: 0.02 },
+            { x: 0.6, y: 0.4, w: 0.35, h: 0.02 },
+            { x: 0.0, y: 0.2, w: 0.1, h: 0.02 },
+            { x: 0.4, y: 0.2, w: 0.6, h: 0.02 }
+          ],
+          hazards: []
         }
       ];
 
@@ -2910,7 +2932,7 @@
           }
         }
 
-        if (currentLevel === 35) {
+        if (levels[currentLevel].stage3Level5) {
           const pivotX = canvas.width / 2;
           const pivotY = canvas.height / 2;
           function rotPtGlobal(x, y, ang) {
@@ -3640,7 +3662,7 @@
       }
 
       function drawStage3Level5Line() {
-        if (currentLevel === 35) {
+        if (levels[currentLevel].stage3Level5) {
           const pivotX = canvas.width / 2;
           const pivotY = canvas.height / 2;
           ctx.save();


### PR DESCRIPTION
## Summary
- introduce new level 6 in stage 3 that reuses the classic platform layout and has the rotating cyan/yellow obstacle
- update collision and drawing logic for the rotating obstacle so it can be reused by multiple levels

## Testing
- `git status --short`