### PR TITLE
Add Stage 3 Level 7

### DIFF
--- a/index.html
+++ b/index.html
@@ -1604,6 +1604,38 @@
             { x: 0.4, y: 0.2, w: 0.6, h: 0.02 }
           ],
           hazards: []
+        },
+        {
+          // -------------------------------------------------
+          // NEW LEVEL: Stage 3 - Level 7 (index 37)
+          // Alternating color gate maze with moving hazards
+          // -------------------------------------------------
+          spawn:  { x: 0.05, y: 0.95 },
+          target: { x: 0.95, y: 0.05 },
+          colorLevel: true,
+          stage: 3,
+          platforms: [],
+          hazards: [
+            { x: 0.30, y: 0.2, w: 0.04, h: 0.08,
+              dy: 1.5, moving: true, verticalMovement: true,
+              minY: 0.2, maxY: 0.8 },
+            { x: 0.50, y: 0.7, w: 0.04, h: 0.08,
+              dy: -1.5, moving: true, verticalMovement: true,
+              minY: 0.2, maxY: 0.8 },
+            { x: 0.70, y: 0.2, w: 0.04, h: 0.08,
+              dy: 2.0, moving: true, verticalMovement: true,
+              minY: 0.2, maxY: 0.8 }
+          ],
+          cyans: [
+            { x: 0.20, y: 0,    w: 0.02, h: 1 },
+            { x: 0.60, y: 0,    w: 0.02, h: 1 },
+            { x: 0.82, y: 0.15, w: 0.18, h: 0.02 }
+          ],
+          yellows: [
+            { x: 0.40, y: 0,    w: 0.02, h: 1 },
+            { x: 0.80, y: 0,    w: 0.02, h: 1 },
+            { x: 0.50, y: 0.45, w: 0.18, h: 0.02 }
+          ]
         }
       ];
 


### PR DESCRIPTION
## Summary
- add new Stage 3 Level 7 featuring color gate maze with moving hazards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dd69286c08325af14dc2878d86187