### PR TITLE
Add Stage 3 Level 10

### DIFF
--- a/index.html
+++ b/index.html
@@ -540,6 +540,8 @@
       let lastChallengePauseStart = 0;
       // Timeout handle for the delayed hazard in Stage 3 Level 3
       let stage3Level3HazardTimeout = null;
+      // Timeout handle for the delayed hazard in Stage 3 Level 10
+      let stage3Level10HazardTimeout = null;
       // Variables for Stage 3 Level 4
       const stage3Level4TargetPositions = [
         { x: 0.5, y: 0.5 },
@@ -1667,6 +1669,36 @@
             { x: 0.4, y: 0.2, w: 0.6, h: 0.02 }
           ],
           hazards: []
+        },
+        {
+          // -------------------------------------------------
+          // NEW LEVEL: Stage 3 - Level 10 (index 39)
+          // Level 6 layout with delayed moving hazard
+          // -------------------------------------------------
+          spawn:  { x: 0.05, y: 0.95 },
+          target: { x: 0.95, y: 0.05 },
+          colorLevel: true,
+          stage: 3,
+          platforms: [
+            { x: 0.20, y: 0.30, w: 0.05, h: 0.70 },
+            { x: 0.50, y: 0.00, w: 0.05, h: 0.70 },
+            { x: 0.80, y: 0.30, w: 0.05, h: 0.70 }
+          ],
+          hazards: [
+            { x: -0.10, y: 0, w: 0.10, h: 1, dx: 1, moving: true, minX: -0.1, maxX: 2 }
+          ],
+          cyans: [
+            { x: 0.00, y: 0.60, w: 1.00, h: 0.02 },
+            { x: 0.00, y: 0.20, w: 1.00, h: 0.02 },
+            { x: 0.30, y: 0.00, w: 0.02, h: 1.00 },
+            { x: 0.60, y: 0.00, w: 0.02, h: 1.00 }
+          ],
+          yellows: [
+            { x: 0.00, y: 0.80, w: 1.00, h: 0.02 },
+            { x: 0.00, y: 0.40, w: 1.00, h: 0.02 },
+            { x: 0.40, y: 0.00, w: 0.02, h: 1.00 },
+            { x: 0.70, y: 0.00, w: 0.02, h: 1.00 }
+          ]
         }
       ];
 
@@ -1734,6 +1766,10 @@
         if (stage3Level3HazardTimeout) {
           clearTimeout(stage3Level3HazardTimeout);
           stage3Level3HazardTimeout = null;
+        }
+        if (stage3Level10HazardTimeout) {
+          clearTimeout(stage3Level10HazardTimeout);
+          stage3Level10HazardTimeout = null;
         }
 
         // Set teleport cooldown based on difficulty, with a special case for
@@ -1926,6 +1962,17 @@
             stage3Level3HazardTimeout = setTimeout(() => {
               hazards.push(delayedHazard);
             }, 1000);
+          }
+        } else if (index === 39) {
+          const movingIndex = hazards.findIndex(h => h.moving);
+          if (movingIndex !== -1) {
+            const delayedHazard = hazards.splice(movingIndex, 1)[0];
+            if (currentMode === "easy") {
+              delayedHazard.dx *= 0.25; // Slow hazard wall in easy mode
+            }
+            stage3Level10HazardTimeout = setTimeout(() => {
+              hazards.push(delayedHazard);
+            }, 2500);
           }
         }
         // Map orange (moving obstacles) definitions
@@ -2138,6 +2185,17 @@
             stage3Level3HazardTimeout = setTimeout(() => {
               hazards.push(delayedHazard);
             }, 500);
+          }
+        } else if (currentLevel === 39) {
+          const movingIndex = hazards.findIndex(h => h.moving);
+          if (movingIndex !== -1) {
+            const delayedHazard = hazards.splice(movingIndex, 1)[0];
+            if (currentMode === "easy") {
+              delayedHazard.dx *= 0.25; // Slow hazard wall in easy mode
+            }
+            stage3Level10HazardTimeout = setTimeout(() => {
+              hazards.push(delayedHazard);
+            }, 2500);
           }
         }
         oranges = (lvl.oranges || []).map(o => ({


### PR DESCRIPTION
## Summary
- add Stage 3 Level 10 data and hazard delay logic
- manage new hazard timeout when changing levels

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684e375a8e448325bc91f2880028be09