### PR TITLE
Update Stage 3 Level 9 hazard speed

### DIFF
--- a/index.html
+++ b/index.html
@@ -540,6 +540,8 @@
       let lastChallengePauseStart = 0;
       // Timeout handle for the delayed hazard in Stage 3 Level 3
       let stage3Level3HazardTimeout = null;
+      // Timeout handle for the delayed hazard in Stage 3 Level 9
+      let stage3Level9HazardTimeout = null;
       // Variables for Stage 3 Level 4
       const stage3Level4TargetPositions = [
         { x: 0.5, y: 0.5 },
@@ -693,6 +695,7 @@
       // 6. Particles for Broken Brown Obstacles
       // -------------------------------------------------
       let brownParticles = []; // Array to hold particle objects
+      let greyParticles = []; // Array for disappearing pillar particles
 
       function spawnBrownParticles(obstacle) {
         const centerX = obstacle.x + obstacle.width / 2;
@@ -700,6 +703,21 @@
         // Generate 12 particles with random velocities and fading transparency
         for (let i = 0; i < 12; i++) {
           brownParticles.push({
+            x: centerX,
+            y: centerY,
+            vx: (Math.random() - 0.5) * 4,
+            vy: -Math.random() * 3,
+            alpha: 1.0,
+            size: 5
+          });
+        }
+      }
+
+      function spawnGreyParticles(rect) {
+        const centerX = rect.x + rect.width / 2;
+        const centerY = rect.y + rect.height / 2;
+        for (let i = 0; i < 12; i++) {
+          greyParticles.push({
             x: centerX,
             y: centerY,
             vx: (Math.random() - 0.5) * 4,
@@ -723,6 +741,19 @@
         }
       }
 
+      function updateGreyParticles() {
+        for (let i = greyParticles.length - 1; i >= 0; i--) {
+          const p = greyParticles[i];
+          p.x += p.vx;
+          p.y += p.vy;
+          p.vy += 0.2;
+          p.alpha -= 0.02;
+          if (p.alpha <= 0) {
+            greyParticles.splice(i, 1);
+          }
+        }
+      }
+
       function drawBrownParticles() {
         ctx.fillStyle = "brown";
         brownParticles.forEach(p => {
@@ -730,6 +761,15 @@
           ctx.fillRect(p.x, p.y, p.size, p.size);
         });
         ctx.globalAlpha = 1.0; // Reset global alpha after drawing particles
+      }
+
+      function drawGreyParticles() {
+        ctx.fillStyle = "grey";
+        greyParticles.forEach(p => {
+          ctx.globalAlpha = p.alpha;
+          ctx.fillRect(p.x, p.y, p.size, p.size);
+        });
+        ctx.globalAlpha = 1.0;
       }
 
       // -------------------------------------------------
@@ -1667,6 +1707,36 @@
             { x: 0.4, y: 0.2, w: 0.6, h: 0.02 }
           ],
           hazards: []
+        },
+        {
+          // -------------------------------------------------
+          // NEW LEVEL: Stage 3 - Level 9 (index 39)
+          // Based on Level 6 but with a delayed moving hazard
+          // -------------------------------------------------
+          spawn:  { x: 0.05, y: 0.95 },
+          target: { x: 0.95, y: 0.05 },
+          colorLevel: true,
+          stage: 3,
+          platforms: [
+            { x: 0.20, y: 0.30, w: 0.05, h: 0.70 },
+            { x: 0.50, y: 0.00, w: 0.05, h: 0.70 },
+            { x: 0.80, y: 0.30, w: 0.05, h: 0.70 }
+          ],
+          hazards: [
+            { x: -0.10, y: 0, w: 0.10, h: 1, dx: 2, moving: true, minX: -0.1, maxX: 2 }
+          ],
+          cyans: [
+            { x: 0.00, y: 0.60, w: 1.00, h: 0.02 },
+            { x: 0.00, y: 0.20, w: 1.00, h: 0.02 },
+            { x: 0.30, y: 0.00, w: 0.02, h: 1.00 },
+            { x: 0.60, y: 0.00, w: 0.02, h: 1.00 }
+          ],
+          yellows: [
+            { x: 0.00, y: 0.80, w: 1.00, h: 0.02 },
+            { x: 0.00, y: 0.40, w: 1.00, h: 0.02 },
+            { x: 0.40, y: 0.00, w: 0.02, h: 1.00 },
+            { x: 0.70, y: 0.00, w: 0.02, h: 1.00 }
+          ]
         }
       ];
 
@@ -1735,6 +1805,10 @@
           clearTimeout(stage3Level3HazardTimeout);
           stage3Level3HazardTimeout = null;
         }
+        if (stage3Level9HazardTimeout) {
+          clearTimeout(stage3Level9HazardTimeout);
+          stage3Level9HazardTimeout = null;
+        }
 
         // Set teleport cooldown based on difficulty, with a special case for
         // the teleport challenge level which always uses 2 seconds
@@ -1775,6 +1849,7 @@
 
         // Clear particles and falling objects from previous level
         brownParticles = [];
+        greyParticles = [];
         fallingOranges = [];
         lastFallingOrangeSpawn = Date.now();
         blues = [];
@@ -1914,7 +1989,9 @@
           minX: (h.minX !== undefined ? h.minX : 0) * canvas.width,
           maxX: (h.maxX !== undefined ? h.maxX : 1) * canvas.width,
           minY: (h.minY !== undefined ? h.minY : 0) * canvas.height,
-          maxY: (h.maxY !== undefined ? h.maxY : 1) * canvas.height
+          maxY: (h.maxY !== undefined ? h.maxY : 1) * canvas.height,
+          savedDx: h.dx || 0,
+          pauseUntil: null
         }));
         if (index === 37) {
           const movingIndex = hazards.findIndex(h => h.moving);
@@ -1926,6 +2003,20 @@
             stage3Level3HazardTimeout = setTimeout(() => {
               hazards.push(delayedHazard);
             }, 1000);
+          }
+        }
+        if (index === 39) {
+          const movingIndex = hazards.findIndex(h => h.moving);
+          if (movingIndex !== -1) {
+            const delayedHazard = hazards.splice(movingIndex, 1)[0];
+            if (currentMode === "easy") {
+              delayedHazard.dx *= 0.25; // Apply easy mode slowdown
+            }
+            stage3Level9HazardTimeout = setTimeout(() => {
+              delayedHazard.savedDx = delayedHazard.dx;
+              delayedHazard.pauseUntil = null;
+              hazards.push(delayedHazard);
+            }, 4000);
           }
         }
         // Map orange (moving obstacles) definitions
@@ -2126,7 +2217,9 @@
           minX: (h.minX !== undefined ? h.minX : 0) * canvas.width,
           maxX: (h.maxX !== undefined ? h.maxX : 1) * canvas.width,
           minY: (h.minY !== undefined ? h.minY : 0) * canvas.height,
-          maxY: (h.maxY !== undefined ? h.maxY : 1) * canvas.height
+          maxY: (h.maxY !== undefined ? h.maxY : 1) * canvas.height,
+          savedDx: h.dx || 0,
+          pauseUntil: null
         }));
         if (currentLevel === 37) {
           const movingIndex = hazards.findIndex(h => h.moving);
@@ -2138,6 +2231,20 @@
             stage3Level3HazardTimeout = setTimeout(() => {
               hazards.push(delayedHazard);
             }, 500);
+          }
+        }
+        if (currentLevel === 39) {
+          const movingIndex = hazards.findIndex(h => h.moving);
+          if (movingIndex !== -1) {
+            const delayedHazard = hazards.splice(movingIndex, 1)[0];
+            if (currentMode === "easy") {
+              delayedHazard.dx *= 0.25; // Apply easy mode slowdown
+            }
+            stage3Level9HazardTimeout = setTimeout(() => {
+              delayedHazard.savedDx = delayedHazard.dx;
+              delayedHazard.pauseUntil = null;
+              hazards.push(delayedHazard);
+            }, 4000);
           }
         }
         oranges = (lvl.oranges || []).map(o => ({
@@ -2697,6 +2804,35 @@
           }
         });
 
+        if (currentLevel === 39) {
+          for (let h of hazards) {
+            if (!h.moving) continue;
+            if (h.pauseUntil && now >= h.pauseUntil) {
+              h.dx = h.savedDx;
+              h.pauseUntil = null;
+            }
+            if (h.pauseUntil) continue;
+            const hRect = { x: h.x, y: h.y, width: h.width, height: h.height };
+            for (let i = 0; i < platforms.length; i++) {
+              const p = platforms[i];
+              const pRect = { x: p.x, y: p.y, width: p.width, height: p.height };
+              if (rectIntersect(hRect, pRect)) {
+                if (h.dx > 0) {
+                  h.x = p.x - h.width;
+                } else {
+                  h.x = p.x + p.width;
+                }
+                h.savedDx = h.dx;
+                h.dx = 0;
+                h.pauseUntil = now + 1500;
+                spawnGreyParticles(p);
+                platforms.splice(i, 1);
+                break;
+              }
+            }
+          }
+        }
+
         // -------------------------------
         // REWORKED MOVEMENT FOR ORANGES & PURPLES
         // -------------------------------
@@ -3198,6 +3334,7 @@
         }
 
         updateBrownParticles();
+        updateGreyParticles();
 
         // Handle any challenge-dashing-level logic (Level 18)
         if (levels[currentLevel].challengeDashingLevel) {
@@ -3989,6 +4126,7 @@
         }
         drawCube();
         drawBrownParticles();
+        drawGreyParticles();
         drawLevelText();
         drawCooldown();
         if (levels[currentLevel].challengeDashingLevel ||


### PR DESCRIPTION
## Summary
- tweak Stage 3 Level 9 delayed hazard so it moves at the same speed as Stage 3 Level 7

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e3a6038f8832592223aaf67020abf