### PR TITLE
Add Stage 3 Level 10

### DIFF
--- a/index.html
+++ b/index.html
@@ -1757,7 +1757,35 @@
             { x: 0.40, y: 0.00, w: 0.02, h: 1.00 },
             { x: 0.70, y: 0.00, w: 0.02, h: 1.00 }
           ]
-        }
+        },
+        {
+          // -------------------------------------------------
+          // NEW LEVEL: Stage 3 - Level 10 (index 40)
+          // Layout from Stage 1 Level 4 with slower rotating line
+          // -------------------------------------------------
+          spawn:  { x: 0.05, y: 0.1 },
+          target: { x: 0.95, y: 0.9 },
+          colorLevel: true,
+          stage: 3,
+          stage3Level5: true,
+          halfSpeedSpin: true,
+          platforms: [
+            { x: 0.0, y: 0.0, w: 1.0, h: 0.02 },
+            { x: 0.0, y: 0.98, w: 1.0, h: 0.02 },
+            { x: 0, y: 594/1080, w: 40/1920, h: 160/1080 },
+            { x: 0.98, y: 0.0, w: 0.02, h: 1.0 },
+            { x: 0.1, y: 0.3, w: 0.6, h: 0.02 },
+            { x: 0.2, y: 0.6, w: 0.6, h: 0.02 },
+            { x: 0.5, y: 0.3, w: 0.02, h: 0.3 }
+          ],
+          hazards: [
+            { x: 0.25, y: 0.45, w: 0.05, h: 0.05 },
+            { x: 0.65, y: 0.55, w: 0.05, h: 0.05 },
+            { x: 0.40, y: 0.20, w: 0.05, h: 0.05 },
+            { x: 0.70, y: 0.75, w: 0.05, h: 0.05 },
+            { x: 0.15, y: 0.70, w: 0.05, h: 0.05 }
+          ]
+        },
       ];
 
       // -------------------------------------------------
@@ -1965,6 +1993,9 @@
           }
           stage3Level5AngularSpeed =
             baseStage3Level5AngularSpeed * (currentMode === "easy" ? 0.6 : currentMode === "hard" ? 1.2 : 1);
+          if (lvl.halfSpeedSpin) {
+            stage3Level5AngularSpeed *= 0.5;
+          }
           target = {
             x: lvl.target.x * canvas.width,
             y: lvl.target.y * canvas.height,
@@ -3406,6 +3437,32 @@
                 }
                 return;
               }
+              } else if (currentLevel === 40 && rectIntersect(cubeRect, targetRect)) {
+                const midX = canvas.width / 2;
+                const midY = canvas.height / 2;
+                if (!(Math.abs(target.x - midX) < 1 && Math.abs(target.y - midY) < 1)) {
+                  target.x = midX;
+                  target.y = midY;
+                  return;
+                } else {
+                  if (currentMode === "hard") {
+                    let hardModeStars = JSON.parse(localStorage.getItem('hardModeStars')) || [];
+                    if (!hardModeStars.includes(currentLevel)) {
+                      hardModeStars.push(currentLevel);
+                    }
+                    localStorage.setItem("hardModeStars", JSON.stringify(hardModeStars));
+                  }
+                  winSound.currentTime = 0;
+                  winSound.play();
+                  currentLevel++;
+                  if (currentLevel < levels.length) {
+                    loadLevel(currentLevel);
+                  } else {
+                    showWinScreen();
+                    return;
+                  }
+                  return;
+                }
             } else if (rectIntersect(cubeRect, targetRect)) {
               // NEW CODE ADDED: star if Hard Mode
               if (currentMode === "hard") {


### PR DESCRIPTION
## Summary
- create Stage 3 Level 10 using Stage 1 Level 4 layout
- reuse the spinning hazard from Stage 3 Level 6 at half speed
- make the target teleport to screen center on first touch

## Testing
- `node -c index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4dffe62883258fcabecc8c530d6c