### PR TITLE
Fix level selector button text alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,15 +80,18 @@
         cursor: not-allowed;
       }
 
-      /* Ensure level selector buttons keep their text centered
-         and prevent overflow */
+      /* Improve level selector buttons so text stays nicely centered */
       #levelSelectorContainer .bigButton {
         display: flex;
         justify-content: center;
         align-items: center;
         text-align: center;
-        white-space: nowrap;
-        overflow: hidden;
+        /* Allow text to wrap rather than spill out */
+        white-space: normal;
+        overflow-wrap: anywhere;
+        /* Ensure consistent button dimensions */
+        min-height: 80px;
+        box-sizing: border-box;
       }
       
       /* ======================================================

--- a/index.html
+++ b/index.html
@@ -79,6 +79,17 @@
         color: #888;
         cursor: not-allowed;
       }
+
+      /* Ensure level selector buttons keep their text centered
+         and prevent overflow */
+      #levelSelectorContainer .bigButton {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+      }
       
       /* ======================================================
          Mode Selection Button Styles (Easy, Normal, Hard)

--- a/index.html
+++ b/index.html
@@ -86,9 +86,10 @@
         justify-content: center;
         align-items: center;
         text-align: center;
-        /* Allow text to wrap rather than spill out */
+        /* Keep text readable without strange line breaks */
         white-space: normal;
-        overflow-wrap: anywhere;
+        overflow-wrap: break-word;
+        font-size: 24px;
         /* Ensure consistent button dimensions */
         min-height: 80px;
         box-sizing: border-box;


### PR DESCRIPTION
## Summary
- keep level selector button text centered and inside its box

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f65a11b5c8325a70a6c62e27723c9