### PR TITLE
Add Stage 3 Level 12

### DIFF
--- a/index.html
+++ b/index.html
@@ -613,6 +613,16 @@
       let stage3Level11NextColor = "cyan";
       let stage3Level11LineSpeed = baseStage3Level4LineSpeed;
       let stage3Level11SpawnInterval = baseStage3Level4SpawnInterval;
+
+      // Variables for Stage 3 Level 12 (sequential teleporting target)
+      const stage3Level12TargetPositions = [
+        { x: 0.95, y: 0.05 }, // top right
+        { x: 0.05, y: 0.05 }, // top left
+        { x: 0.05, y: 0.95 }, // bottom left
+        { x: 0.95, y: 0.95 }, // bottom right
+        { x: 0.5, y: 0.5 }    // center
+      ];
+      let stage3Level12Index = 0;
       // =====================================================================
 
       // -------------------------------------------------
@@ -1836,6 +1846,22 @@
             { x: 0.4, y: 0.6, w: 0.1, h: 0.1 },
             { x: 0.7, y: 0.3, w: 0.1, h: 0.1 }
           ]
+        },
+        {
+          // -------------------------------------------------
+          // NEW LEVEL: Stage 3 - Level 12 (index 42)
+          // Plus obstacle with sequentially teleporting target
+          // -------------------------------------------------
+          spawn: { x: 0.05, y: 0.95 },
+          target: { x: 0.95, y: 0.05 },
+          colorLevel: true,
+          stage: 3,
+          stage3Level12: true,
+          stage3Level5: true,
+          halfSpinSpeed: true,
+          doubleSpinLine: true,
+          platforms: [],
+          hazards: []
         }
       ];
 
@@ -2024,6 +2050,31 @@
           target = {
             x: stage3Level4TargetPositions[0].x * canvas.width,
             y: stage3Level4TargetPositions[0].y * canvas.height,
+            size: cube.size
+          };
+        } else if (lvl.stage3Level12) {
+          stage3Level5Angle = 0;
+          stage3Level5Segments = [];
+          stage3DoubleLine = true;
+          const count = stage3Level5SegmentColors.length;
+          const baseSegH = canvas.height / count;
+          const segH = baseSegH * 3;
+          const segSpacing = segH;
+          const segW = 0.02 * canvas.width;
+          for (let i = 0; i < count; i++) {
+            stage3Level5Segments.push({
+              offset: (i - (count - 1) / 2) * segSpacing,
+              width: segW,
+              height: segH,
+              color: stage3Level5SegmentColors[i]
+            });
+          }
+          stage3Level5AngularSpeed =
+            baseStage3Level5AngularSpeed * (currentMode === "easy" ? 0.6 : currentMode === "hard" ? 1.2 : 1) * 0.5;
+          stage3Level12Index = 0;
+          target = {
+            x: stage3Level12TargetPositions[0].x * canvas.width,
+            y: stage3Level12TargetPositions[0].y * canvas.height,
             size: cube.size
           };
         } else if (lvl.stage3Level5) {
@@ -3517,6 +3568,32 @@
               if (stage3Level4Index < stage3Level4TargetPositions.length - 1) {
                 target.x = stage3Level4TargetPositions[stage3Level4Index].x * canvas.width;
                 target.y = stage3Level4TargetPositions[stage3Level4Index].y * canvas.height;
+                return;
+              } else {
+                if (currentMode === "hard") {
+                  let hardModeStars = JSON.parse(localStorage.getItem('hardModeStars')) || [];
+                  if (!hardModeStars.includes(currentLevel)) {
+                    hardModeStars.push(currentLevel);
+                  }
+                  localStorage.setItem('hardModeStars', JSON.stringify(hardModeStars));
+                  updateStarProgress();
+                }
+                winSound.currentTime = 0;
+                winSound.play();
+                currentLevel++;
+                if (currentLevel < levels.length) {
+                  loadLevel(currentLevel);
+                } else {
+                  showWinScreen();
+                  return;
+                }
+                return;
+              }
+            } else if (levels[currentLevel].stage3Level12 && rectIntersect(cubeRect, targetRect)) {
+              stage3Level12Index++;
+              if (stage3Level12Index < stage3Level12TargetPositions.length) {
+                target.x = stage3Level12TargetPositions[stage3Level12Index].x * canvas.width;
+                target.y = stage3Level12TargetPositions[stage3Level12Index].y * canvas.height;
                 return;
               } else {
                 if (currentMode === "hard") {


### PR DESCRIPTION
## Summary
- add new sequential-teleport level for Stage 3
- support Stage 3 Level 12 in the loader and game loop
- include rotating plus obstacle for the new level

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684fade00ce0832588335f5329b943e8