### PR TITLE
Fix layering for green target

### DIFF
--- a/index.html
+++ b/index.html
@@ -1860,6 +1860,7 @@
           halfSpinSpeed: true,
           doubleSpinLine: true,
           stage3Level12: true,
+          targetOnTop: true,
           platforms: [],
           hazards: []
         }
@@ -4449,7 +4450,9 @@
           ctx.fillStyle = "black";
           ctx.fillRect(0, 0, canvas.width, canvas.height);
         }
-       if (!(levels[currentLevel].targetOnTop && stage3Level10Teleported)) {
+       const targetShouldBeOnTop = levels[currentLevel].targetOnTop &&
+         (!levels[currentLevel].teleportToCenter || stage3Level10Teleported);
+       if (!targetShouldBeOnTop) {
          drawTarget();
        }
        drawPlatforms();
@@ -4474,7 +4477,7 @@
         drawGreyParticles();
         drawLevelText();
       drawCooldown();
-      if (levels[currentLevel].targetOnTop && stage3Level10Teleported) {
+      if (targetShouldBeOnTop) {
         drawTarget();
       }
         if (levels[currentLevel].challengeDashingLevel ||


### PR DESCRIPTION
## Summary
- draw the target on top whenever the level specifies `targetOnTop`
- mark the final level so that its target overlays other objects

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684fb24ab27083258bcac51e5cf5d010