### PR TITLE
Add Stage 3 Level 14 with new charging block

### DIFF
--- a/index.html
+++ b/index.html
@@ -754,7 +754,7 @@
       function drawChargeProgress() {
         if (levels[currentLevel].chargingTarget) {
           ctx.fillStyle = "#fff";
-          ctx.font = "20px sans-serif";
+          ctx.font = "28px sans-serif";
           ctx.textAlign = "left";
           const percent = Math.floor((chargeProgress / chargeDuration) * 100);
           ctx.fillText(percent + "%", 10, 80);
@@ -1891,6 +1891,23 @@
           chargeTime: 3000,
           platforms: [],
           hazards: []
+        },
+        {
+          // -------------------------------------------------
+          // NEW LEVEL: Stage 3 - Level 14 (index 44)
+          // Large charging block with immediate falling color lines
+          // -------------------------------------------------
+          spawn: { x: 0.5, y: 0.95 },
+          target: { x: 0.5, y: 0.5 },
+          colorLevel: true,
+          stage: 3,
+          stage3Level4: true,
+          stage3Level4Start: true,
+          chargingTarget: true,
+          chargeTime: 20000,
+          targetSize: 160,
+          platforms: [],
+          hazards: []
         }
       ];
 
@@ -2066,12 +2083,12 @@
           target = {
             x: level13TargetPositions[0].x * canvas.width,
             y: level13TargetPositions[0].y * canvas.height,
-            size: cube.size
+            size: lvl.targetSize || cube.size
           };
         } else if (lvl.stage3Level4) {
           stage3Level4Index = 0;
           stage3Level4Lines = [];
-          stage3Level4Triggered = false;
+          stage3Level4Triggered = !!lvl.stage3Level4Start;
           stage3Level4LastSpawn = Date.now();
           stage3Level4NextColor = "cyan";
           stage3Level4LineSpeed =
@@ -2081,7 +2098,7 @@
           target = {
             x: stage3Level4TargetPositions[0].x * canvas.width,
             y: stage3Level4TargetPositions[0].y * canvas.height,
-            size: cube.size
+            size: lvl.targetSize || cube.size
           };
         } else if (lvl.stage3Level5) {
           stage3Level5Angle = lvl.stage3Level12 ? stage3Level12StartAngle : 0;
@@ -2107,13 +2124,13 @@
             target = {
               x: stage3Level12TargetPositions[0].x * canvas.width,
               y: stage3Level12TargetPositions[0].y * canvas.height,
-              size: cube.size
+              size: lvl.targetSize || cube.size
             };
           } else {
             target = {
               x: lvl.target.x * canvas.width,
               y: lvl.target.y * canvas.height,
-              size: cube.size
+              size: lvl.targetSize || cube.size
             };
           }
         } else if (lvl.stage3Level11) {
@@ -2127,7 +2144,7 @@
           target = {
             x: lvl.target.x * canvas.width,
             y: lvl.target.y * canvas.height,
-            size: cube.size
+            size: lvl.targetSize || cube.size
           };
         } else if (lvl.fallingBrownLevel) {
           fallingBrownBlocks = [];
@@ -2138,7 +2155,7 @@
           target = {
             x: lvl.target.x * canvas.width,
             y: lvl.target.y * canvas.height,
-            size: cube.size
+            size: lvl.targetSize || cube.size
           };
         }
 
@@ -2374,13 +2391,13 @@
           target = {
             x: level13TargetPositions[level13Stage].x * canvas.width,
             y: level13TargetPositions[level13Stage].y * canvas.height,
-            size: cube.size
+            size: lvl.targetSize || cube.size
           };
         } else if (!lvl.fallingBrownLevel && !lvl.challengeDashingLevel) {
           target = {
             x: lvl.target.x * canvas.width,
             y: lvl.target.y * canvas.height,
-            size: cube.size
+            size: lvl.targetSize || cube.size
           };
         }
         platforms = (lvl.platforms || []).map(p => ({


### PR DESCRIPTION
## Summary
- introduce Stage 3 Level 14
- level uses a large light green block that charges at 5% per second
- color lines start spawning immediately using Stage 3-5 rates
- allow custom target size and starting line spawn logic
- enlarge charge percentage display text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850621039648325b819f735933ea298