### PR TITLE
Update music handling in game

### DIFF
--- a/index.html
+++ b/index.html
@@ -2148,6 +2148,10 @@
           const prevStage = levels[prevLevel] ? (levels[prevLevel].stage || 1) : 1;
           const newStage = lvl.stage || 1;
           handleStageMusicTransition(prevStage, newStage);
+          // Ensure the correct track is playing when the stage doesn't change
+          if (settings.music && prevStage === newStage) {
+            playBackgroundMusicForStage(newStage);
+          }
 
         // Clear any pending checkpoint auto-kill
         if (checkpointKillTimeout) {
@@ -4957,6 +4961,8 @@
       function backToMainMenu() {
         hideLevelSelector();
         mainMenu.classList.remove("hidden");
+        // Ensure no music plays on the main menu
+        [bgEasyNormalMusic, bgHardMusic, stage3EasyMusic, stage3HardMusic].forEach(a => fadeOut(a, 500));
         updateStarProgress();
         gamePaused = true;
       }
@@ -4966,6 +4972,8 @@
         levelSelectorFromMainMenu = fromMainMenu;
         levelSelectorActive = true;
         gamePaused = true;
+        // Stop any currently playing music when the selector opens
+        [bgEasyNormalMusic, bgHardMusic, stage3EasyMusic, stage3HardMusic].forEach(a => fadeOut(a, 500));
         if (levelSelectorFromMainMenu) {
           const highestUnlockedIndex = Math.min(maxUnlockedLevel, levels.length - 1);
           currentStage = levels[highestUnlockedIndex].stage || 1;
@@ -4986,6 +4994,10 @@
         levelSelectorActive = false;
         gamePaused = false;
         levelSelectorOverlay.classList.add("hidden");
+        if (!levelSelectorFromMainMenu && settings.music) {
+          playBackgroundMusicForStage(levels[currentLevel].stage || 1);
+        }
+        levelSelectorFromMainMenu = false;
       }
 
       document.getElementById("stageLeft").addEventListener("click", () => {
@@ -5196,9 +5208,7 @@
           currentMode = savedMode;
           updateModeParameters();
           updateModeButtons();
-          if (settings.music) {
-            playBackgroundMusicForStage(levels[currentLevel].stage || 1);
-          }
+          // Do not start music yet; wait until gameplay begins
         }
       // Immediately reflect them on the checkboxes
       toggleSoundEffects.checked = settings.soundEffects;


### PR DESCRIPTION
## Summary
- stop music before opening level selector and resume when closing
- ensure no music plays on main menu
- maintain correct music after each level transition
- don't start music until gameplay begins

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850eaa78bd48325807892ed4cbcd563