### PR TITLE
Fix music resume after tab switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -5214,12 +5214,14 @@
       // -------------------------------------------------
       let wasMusicOnBefore = settings.music;
       let wereSoundsOnBefore = settings.soundEffects;
+      let previousMusic = null;
       
       document.addEventListener("visibilitychange", function() {
         if (document.hidden) {
-          // Save current settings so we can restore them later
-          wasMusicOnBefore = settings.music && musicManager.current;
+          // Save current music and sound effect preferences
+          wasMusicOnBefore = settings.music;
           wereSoundsOnBefore = settings.soundEffects;
+          previousMusic = musicManager.current;
 
           // Turn them off
           settings.soundEffects = false;
@@ -5231,10 +5233,11 @@
           // Restore them
           settings.music = wasMusicOnBefore;
           settings.soundEffects = wereSoundsOnBefore;
-          if (settings.music && wasMusicOnBefore) {
+          if (settings.music && previousMusic) {
             const stage = levels[currentLevel].stage || 1;
             playMusicForStage(stage);
           }
+          previousMusic = null;
         }
       });
 

--- a/index.html
+++ b/index.html
@@ -530,7 +530,9 @@
             if (audio.fadeInterval) clearInterval(audio.fadeInterval);
             audio.pause();
             audio.currentTime = 0;
-            this.current = null;
+            if (this.current === audio) {
+              this.current = null;
+            }
           };
           if (!fade) {
             end();
@@ -540,7 +542,9 @@
         },
         play(newAudio) {
           if (this.current === newAudio) {
-            if (newAudio.paused) this._fadeIn(newAudio, newAudio.baseVolume);
+            if (newAudio.fadeInterval) clearInterval(newAudio.fadeInterval);
+            if (newAudio.paused) newAudio.play();
+            newAudio.volume = newAudio.baseVolume;
             return;
           }
           const old = this.current;


### PR DESCRIPTION
## Summary
- ensure music preference isn't lost when tabbing out during level selection
- resume music only if a track was playing before switching tabs

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/GravityFlip/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6851cb71d04c83259919cbffa5dc6dd4