### PR TITLE
Improve final star targeting

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,10 @@
          ====================================================== -->
     <div id="mainMenu" class="overlay">
       <h1 style="font-size:64px; margin-bottom:20px;">Gravity Flipper</h1>
-      <div id="starProgress" class="hidden" style="font-size:32px; margin-bottom:20px;">0/0 ★</div>
+      <div id="starProgress" class="hidden" style="font-size:32px; margin-bottom:20px;">
+        <span id="starCount">0/0</span>
+        <span id="starProgressIcon">★</span>
+      </div>
       <!-- Button to start the game -->
       <div id="playButton" class="bigButton">Play</div>
       <!-- Button to open the level selector overlay -->
@@ -5270,6 +5273,8 @@
       const playButton = document.getElementById("playButton");
       const menuLevelSelectorButton = document.getElementById("menuLevelSelectorButton");
       const starProgress = document.getElementById("starProgress");
+      const starCount = document.getElementById("starCount");
+      const starProgressIcon = document.getElementById("starProgressIcon");
       const finalStarOverlay = document.getElementById("finalStarOverlay");
       const finalStar = document.getElementById("finalStar");
       const clearStoragePrompt = document.getElementById("clearStoragePrompt");
@@ -5387,7 +5392,7 @@
         const count = hardModeStars.length + (finalAwarded ? 1 : 0);
         if (count > 0) {
           starProgress.classList.remove('hidden');
-          starProgress.textContent = `${count}/${totalStars} \u2605`;
+          starCount.textContent = `${count}/${totalStars}`;
           if (count === totalStars) {
             starProgress.classList.add('gold');
           } else {
@@ -5405,13 +5410,15 @@
       function awardFinalStar() {
         finalStarOverlay.classList.remove('hidden');
         finalStar.style.display = 'none';
-        const rect = starProgress.getBoundingClientRect();
-        finalStar.style.top = (rect.top - 75) + 'px';  // move 75px upward
+        const iconRect = starProgressIcon.getBoundingClientRect();
+        finalStar.style.top = (iconRect.top - 75) + 'px';  // move 75px upward
         finalStar.style.left = '-80px';
         setTimeout(() => {
           finalStar.style.display = 'block';
           requestAnimationFrame(() => {
-            finalStar.style.left = rect.left + 'px';
+            const updatedRect = starProgressIcon.getBoundingClientRect();
+            const targetLeft = updatedRect.left + updatedRect.width / 2 - finalStar.offsetWidth / 2;
+            finalStar.style.left = targetLeft + 'px';
           });
         }, 3000);
         finalStar.addEventListener('transitionend', () => {


### PR DESCRIPTION
## Summary
- break out star progress text so we can measure the star icon
- update star counting logic to use new `starCount` span
- precisely position the reward star on the star count icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68537ce465008325a88cfa3658e4e0bd