### PR TITLE
Add Bullet hell extra challenge

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,6 +329,11 @@
       <div class="bigButton" id="replayButton">Replay?</div>
     </div>
 
+    <div id="challengeWin" class="overlay hidden">
+      <h1 id="challengeWinText" style="font-size:64px; margin-bottom:40px;"></h1>
+      <div class="bigButton" id="challengeReturn">Go to challenges</div>
+    </div>
+
     <!-- ======================================================
          Settings Menu Overlay: Allows players to configure game settings.
          ====================================================== -->
@@ -659,6 +664,8 @@
       // Flag that indicates whether all levels are unlocked (for cheat mode)
       let allLevelsUnlocked = false;
 
+      let extraChallengesUnlocked = localStorage.getItem('extraChallengesUnlocked') === 'true';
+
       // Flag to indicate if the level selector was accessed from the main menu
       let levelSelectorFromMainMenu = false;
 
@@ -801,6 +808,10 @@
       // Variables for Stage 3 Level 13 charge block
       let chargeProgress = 0;
       let chargeDuration = 3000;
+      // Globals for Bullet Hell challenge
+      let bulletHellStartTime = 0;
+      let bulletHellLastSpawn = 0;
+      const bulletHellDuration = 45000;
       // =====================================================================
 
       // -------------------------------------------------
@@ -986,6 +997,56 @@
           p.alpha -= 0.02; // Gradually reduce opacity
           if (p.alpha <= 0) {
             brownParticles.splice(i, 1);
+          }
+        }
+
+        // Handle Bullet Hell challenge logic
+        if (levels[currentLevel].bulletHellLevel) {
+          let elapsed = Date.now() - bulletHellStartTime;
+          let remaining = bulletHellDuration - elapsed;
+          let spawnInterval = 2000;
+          let spawnCount = 1;
+          if (remaining <= 30000 && remaining > 15000) {
+            spawnInterval = 1000;
+          } else if (remaining <= 15000 && remaining > 5000) {
+            spawnInterval = 1000;
+            spawnCount = 2;
+          } else if (remaining <= 5000) {
+            spawnInterval = 500;
+          }
+          if (Date.now() - bulletHellLastSpawn >= spawnInterval && remaining > 0) {
+            for (let i = 0; i < spawnCount; i++) {
+              let side = Math.floor(Math.random() * 4);
+              let block = { width: cube.size, height: cube.size, vx: 0, vy: 0, x: 0, y: 0, spawnTime: Date.now() };
+              if (side === 0) { block.x = -cube.size; block.y = Math.random() * (canvas.height - cube.size); block.vx = 2; }
+              else if (side === 1) { block.x = canvas.width; block.y = Math.random() * (canvas.height - cube.size); block.vx = -2; }
+              else if (side === 2) { block.x = Math.random() * (canvas.width - cube.size); block.y = -cube.size; block.vy = 2; }
+              else { block.x = Math.random() * (canvas.width - cube.size); block.y = canvas.height; block.vy = -2; }
+              fallingRedBlocks.push(block);
+            }
+            bulletHellLastSpawn = Date.now();
+          }
+          for (let i = fallingRedBlocks.length - 1; i >= 0; i--) {
+            let block = fallingRedBlocks[i];
+            block.x += block.vx;
+            block.y += block.vy;
+            if (block.x > canvas.width || block.x + block.width < 0 || block.y > canvas.height || block.y + block.height < 0) {
+              fallingRedBlocks.splice(i, 1);
+              continue;
+            }
+            let r = { x: block.x, y: block.y, width: block.width, height: block.height };
+            if (Date.now() - block.spawnTime >= 250 && rectIntersect(cubeRect, r)) {
+              if (!(isDashing || Date.now() < dashGraceUntil)) {
+                deathSound.currentTime = 0; deathSound.play(); loadLevel(currentLevel); return; }
+            }
+          }
+          if (remaining <= 0 && !challengeGreenBlock) {
+            challengeGreenBlock = { x: canvas.width/2, y: canvas.height/2, size: 200 };
+          }
+          if (challengeGreenBlock) {
+            let g = { x: challengeGreenBlock.x - challengeGreenBlock.size/2, y: challengeGreenBlock.y - challengeGreenBlock.size/2, width: challengeGreenBlock.size, height: challengeGreenBlock.size };
+            if (rectIntersect(cubeRect, g)) {
+              winSound.currentTime = 0; winSound.play(); showChallengeWin('Bullet hell'); return; }
           }
         }
       }
@@ -2161,6 +2222,19 @@
           chargeTime: 15000,
           stage: 3,
           platforms: [],
+        hazards: []
+        },
+        {
+          // -------------------------------------------------
+          // EXTRA CHALLENGE: Bullet hell (index 49)
+          // -------------------------------------------------
+          bulletHellLevel: true,
+          extraChallenge: true,
+          name: "Bullet hell",
+          stage: 4,
+          spawn: { x: 0.5, y: 0.95 },
+          target: null,
+          platforms: [],
           hazards: []
         }
       ];
@@ -2169,7 +2243,7 @@
       // 8. Update maxUnlockedLevel if currentLevel exceeds it
       // -------------------------------------------------
       function updateUnlockedProgress() {
-        if (currentLevel > maxUnlockedLevel) {
+        if (!levels[currentLevel].extraChallenge && currentLevel > maxUnlockedLevel) {
           maxUnlockedLevel = currentLevel;
           localStorage.setItem('maxUnlockedLevel', maxUnlockedLevel);
         }
@@ -2351,6 +2425,12 @@
           lastColorRedSpawn = Date.now();
           chargeProgress = 0;
           chargeDuration = lvl.chargeTime || 5000;
+        } else if (lvl.bulletHellLevel) {
+          target = null;
+          bulletHellStartTime = Date.now();
+          bulletHellLastSpawn = Date.now();
+          fallingRedBlocks = [];
+          challengeGreenBlock = null;
         } else if (lvl.level13) {
           level13Stage = 0;
           level13PillarsSpawned = false;
@@ -3097,7 +3177,7 @@
                 winSound.currentTime = 0;
                 winSound.play();
                 // NEW CODE ADDED: if Hard Mode, record a star for the level
-                if (currentMode === "hard") {
+                if (currentMode === "hard" && !levels[currentLevel].extraChallenge) {
                   let hardModeStars = JSON.parse(localStorage.getItem('hardModeStars')) || [];
                   if (!hardModeStars.includes(currentLevel)) {
                     hardModeStars.push(currentLevel);
@@ -3961,7 +4041,7 @@
               return;
             } else {
               // NEW CODE ADDED: star if Hard Mode
-              if (currentMode === "hard") {
+              if (currentMode === "hard" && !levels[currentLevel].extraChallenge) {
                 let hardModeStars = JSON.parse(localStorage.getItem('hardModeStars')) || [];
                 if (!hardModeStars.includes(currentLevel)) {
                   hardModeStars.push(currentLevel);
@@ -4004,7 +4084,7 @@
                 target.y = stage3Level4TargetPositions[stage3Level4Index].y * canvas.height;
                 return;
               } else {
-                if (currentMode === "hard") {
+                if (currentMode === "hard" && !levels[currentLevel].extraChallenge) {
                   let hardModeStars = JSON.parse(localStorage.getItem('hardModeStars')) || [];
                   if (!hardModeStars.includes(currentLevel)) {
                     hardModeStars.push(currentLevel);
@@ -4107,7 +4187,7 @@
               }
             } else if (rectIntersect(cubeRect, targetRect)) {
               // NEW CODE ADDED: star if Hard Mode
-              if (currentMode === "hard") {
+              if (currentMode === "hard" && !levels[currentLevel].extraChallenge) {
                 let hardModeStars = JSON.parse(localStorage.getItem('hardModeStars')) || [];
                 if (!hardModeStars.includes(currentLevel)) {
                   hardModeStars.push(currentLevel);
@@ -4285,7 +4365,7 @@
             };
             if (rectIntersect(cubeRect, greenRect)) {
               // NEW CODE ADDED: star if Hard Mode
-              if (currentMode === "hard") {
+              if (currentMode === "hard" && !levels[currentLevel].extraChallenge) {
                 let hardModeStars = JSON.parse(localStorage.getItem('hardModeStars')) || [];
                 if (!hardModeStars.includes(currentLevel)) {
                   hardModeStars.push(currentLevel);
@@ -4560,7 +4640,7 @@
               height: challengeGreenBlock.size
             };
             if (rectIntersect(cubeRect, greenRect)) {
-              if (currentMode === "hard") {
+              if (currentMode === "hard" && !levels[currentLevel].extraChallenge) {
                 let hardModeStars = JSON.parse(localStorage.getItem('hardModeStars')) || [];
                 if (!hardModeStars.includes(currentLevel)) {
                   hardModeStars.push(currentLevel);
@@ -4676,13 +4756,17 @@
                 colorPhaseStart = Date.now();
               } else {
                 chargeProgress = chargeDuration;
-                if (currentMode === "hard") {
+                if (currentMode === "hard" && !levels[currentLevel].extraChallenge) {
                   let hardModeStars = JSON.parse(localStorage.getItem('hardModeStars')) || [];
                   if (!hardModeStars.includes(currentLevel)) hardModeStars.push(currentLevel);
                   localStorage.setItem('hardModeStars', JSON.stringify(hardModeStars));
                   updateStarProgress();
                 }
-                winSound.currentTime=0; winSound.play(); currentLevel++; if(currentLevel<levels.length){ loadLevel(currentLevel); } else { showWinScreen(); } return;
+                winSound.currentTime=0; winSound.play();
+                extraChallengesUnlocked = true;
+                localStorage.setItem('extraChallengesUnlocked','true');
+                showWinScreen();
+                return;
               }
             }
           }
@@ -4840,7 +4924,8 @@
       }
       function drawFallingRedBlocks() {
         if (levels[currentLevel].challengeDashingLevel ||
-            (levels[currentLevel].challengeTeleportLevel && challengePhase >= 2)) {
+            (levels[currentLevel].challengeTeleportLevel && challengePhase >= 2) ||
+            levels[currentLevel].bulletHellLevel) {
           ctx.fillStyle = levels[currentLevel].challengeTeleportLevel ? "purple" : "red";
           for (let block of fallingRedBlocks) {
             ctx.fillRect(block.x, block.y, block.width, block.height);
@@ -4897,7 +4982,8 @@
       }
       function drawChallengeGreenBlock() {
         if ((levels[currentLevel].challengeDashingLevel ||
-             (levels[currentLevel].challengeTeleportLevel && challengePhase === 3)) && challengeGreenBlock) {
+             (levels[currentLevel].challengeTeleportLevel && challengePhase === 3) ||
+             levels[currentLevel].bulletHellLevel) && challengeGreenBlock) {
           ctx.fillStyle = "green";
           ctx.fillRect(
             challengeGreenBlock.x - challengeGreenBlock.size / 2,
@@ -4950,6 +5036,13 @@
           } else {
             ctx.fillText("Challenge Of Colors 1/3", 10, 40);
           }
+        } else if (levels[currentLevel].bulletHellLevel) {
+          ctx.fillText("Bullet hell", 10, 40);
+          let elapsed = Date.now() - bulletHellStartTime;
+          let remainingSec = Math.max(0, Math.ceil((bulletHellDuration - elapsed) / 1000));
+          ctx.textAlign = "center";
+          ctx.fillText(remainingSec + "s", canvas.width / 2, 40);
+          ctx.textAlign = "left";
         } else {
           let stage = levels[currentLevel].stage || 1;
           let levelNumInStage = 1;
@@ -5160,25 +5253,33 @@
           if (lvlStage === currentStage) {
             const btn = document.createElement("div");
             btn.className = "bigButton";
-            let count = 0;
-            for (let j = 0; j < index; j++) {
-              if ((levels[j].stage || 1) === lvlStage) {
-                count++;
-              }
-            }
-            if (index === 30) {
-              btn.textContent = "Level 13";
+            let label = "";
+            if (lvl.extraChallenge) {
+              label = lvl.name;
+            } else if (index === 30) {
+              label = "Level 13";
             } else {
-              btn.textContent = "Level " + (count + 1);
+              let count = 0;
+              for (let j = 0; j < index; j++) {
+                if ((levels[j].stage || 1) === lvlStage) count++;
+              }
+              label = "Level " + (count + 1);
             }
-            
-            if (!allLevelsUnlocked && index > maxUnlockedLevel) {
-              btn.textContent += " 🔒";
+
+            let locked = false;
+            if (lvl.extraChallenge) {
+              locked = !allLevelsUnlocked && !extraChallengesUnlocked;
+            } else {
+              locked = !allLevelsUnlocked && index > maxUnlockedLevel;
+            }
+
+            if (locked) {
+              btn.textContent = label + " 🔒";
               btn.classList.add("locked");
             } else {
-              // If it's unlocked, check if we have a hard-mode star for it
-              if (hardModeStars.includes(index)) {
-                btn.textContent += " ★"; // star symbol to show hard-mode completion
+              btn.textContent = label;
+              if (!lvl.extraChallenge && hardModeStars.includes(index)) {
+                btn.textContent += " ★";
               }
               btn.addEventListener("click", () => {
                 hideLevelSelector();
@@ -5190,7 +5291,8 @@
             levelSelectorContainer.appendChild(btn);
           }
         });
-        document.getElementById("stageHeader").textContent = "Stage " + currentStage + " - Select Level";
+        const header = currentStage === 4 ? "Extra Challenges - Select Challenge" : "Stage " + currentStage + " - Select Level";
+        document.getElementById("stageHeader").textContent = header;
       }
 
       function backToMainMenu() {
@@ -5239,7 +5341,8 @@
         populateLevelSelector();
       });
       document.getElementById("stageRight").addEventListener("click", () => {
-        currentStage++;
+        const maxStage = (extraChallengesUnlocked || allLevelsUnlocked) ? 4 : 3;
+        currentStage = Math.min(maxStage, currentStage + 1);
         populateLevelSelector();
       });
 
@@ -5248,10 +5351,24 @@
       // -------------------------------------------------
       const winScreen = document.getElementById("winScreen");
       const replayButton = document.getElementById("replayButton");
+      const challengeWin = document.getElementById("challengeWin");
+      const challengeWinText = document.getElementById("challengeWinText");
+      const challengeReturn = document.getElementById("challengeReturn");
 
       function showWinScreen() {
         gamePaused = true;
         winScreen.classList.remove("hidden");
+      }
+
+      function showChallengeWin(name) {
+        challengeWinText.textContent = `You won ${name}!`;
+        gamePaused = true;
+        challengeWin.classList.remove("hidden");
+      }
+
+      function hideChallengeWin() {
+        challengeWin.classList.add("hidden");
+        gamePaused = false;
       }
 
       function hideWinScreen() {
@@ -5261,6 +5378,13 @@
 
       replayButton.addEventListener("click", () => {
         window.location.reload();
+      });
+
+      challengeReturn.addEventListener("click", () => {
+        hideChallengeWin();
+        showLevelSelector(false, false);
+        currentStage = 4;
+        populateLevelSelector();
       });
 
       // -------------------------------------------------
@@ -5383,7 +5507,8 @@
       function updateStarProgress() {
         const hardModeStars = JSON.parse(localStorage.getItem('hardModeStars')) || [];
         const finalAwarded = localStorage.getItem('finalStarAwarded') === 'true';
-        const totalStars = levels.length + 1;
+        const playableLevels = levels.filter(l => !l.extraChallenge).length;
+        const totalStars = playableLevels + 1;
         const count = hardModeStars.length + (finalAwarded ? 1 : 0);
         if (count > 0) {
           starProgress.classList.remove('hidden');
@@ -5397,7 +5522,7 @@
           starProgress.classList.add('hidden');
         }
 
-        if (!finalAwarded && hardModeStars.length === levels.length) {
+        if (!finalAwarded && hardModeStars.length === playableLevels) {
           awardFinalStar();
         }
       }


### PR DESCRIPTION
## Summary
- add new Bullet hell challenge stage
- display challenge win overlay and new stage navigation
- modify level selector and star progress for extra challenges
- implement Bullet hell mechanics and UI text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855a79dc54483259e24087428381ec9