### PR TITLE
Update bullet hell and unlock extras after color challenge

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,6 +326,9 @@
          ====================================================== -->
     <div id="winScreen" class="overlay hidden">
       <h1 id="winTitle" style="font-size:64px; margin-bottom:40px;">You Win!</h1>
+      <div id="extraUnlockText" class="hidden" style="font-size:32px; margin-bottom:20px;">
+        Extra Challenges unlocked in level selector
+      </div>
       <div class="bigButton" id="replayButton">Replay</div>
       <div class="bigButton hidden" id="goChallengesButton" style="margin-top:20px;">Go to Challenges</div>
     </div>
@@ -665,8 +668,10 @@
 
       let modeBeforeChallenge = null;
 
+      // Track if the Challenge of Colors has been beaten
+      let challengeOfColorsBeaten = localStorage.getItem('challengeOfColorsBeaten') === 'true';
       // Track if the extra challenges have been unlocked
-      let extraChallengesUnlocked = localStorage.getItem('extraChallengesUnlocked') === 'true';
+      let extraChallengesUnlocked = challengeOfColorsBeaten || localStorage.getItem('extraChallengesUnlocked') === 'true';
       let maxStageUnlocked = extraChallengesUnlocked ? 4 : 3;
 
       // -------------------------------------------------
@@ -4678,15 +4683,19 @@
           let elapsed = (now - bulletHellStartTime) - challengePausedTime;
           let remaining = bulletHellDuration - elapsed;
           let spawnInterval = 1000;
-          let spawnCount = 1;
+          let spawnCount = 2;
           if (remaining > 30000) {
-            spawnCount = 1; // 45s-31s
-          } else if (remaining > 15000) {
-            spawnCount = 2; // 30s-16s
+            spawnInterval = 1000; // 45s-31s
+            spawnCount = 2;
+          } else if (remaining > 16000) {
+            spawnInterval = 1000; // 30s-16s
+            spawnCount = 3;
           } else if (remaining > 5000) {
-            spawnCount = 3; // 15s-6s
+            spawnInterval = 1250; // 15s-6s
+            spawnCount = 5;
           } else {
-            spawnCount = 4; // last 5s
+            spawnInterval = 750; // last 5s
+            spawnCount = 5;
           }
           if (now - bulletHellLastSpawn >= spawnInterval) {
             for (let i = 0; i < spawnCount; i++) {
@@ -5319,10 +5328,11 @@
       const winScreen = document.getElementById("winScreen");
       const replayButton = document.getElementById("replayButton");
       const goChallengesButton = document.getElementById("goChallengesButton");
+      const extraUnlockText = document.getElementById("extraUnlockText");
 
       const winTitle = document.getElementById("winTitle");
 
-      function showWinScreen(challengeName = null) {
+      function showWinScreen(challengeName = null, colorUnlock = false) {
         gamePaused = true;
         musicManager.stop(true);
 
@@ -5333,7 +5343,11 @@
         } else {
           winTitle.textContent = "You Win!";
           replayButton.classList.remove('hidden');
-          if (currentLevel >= levels.length) {
+          extraUnlockText.classList.add('hidden');
+          if (colorUnlock) {
+            extraUnlockText.classList.remove('hidden');
+            goChallengesButton.classList.add('hidden');
+          } else if (currentLevel >= levels.length) {
             extraChallengesUnlocked = true;
             localStorage.setItem('extraChallengesUnlocked', 'true');
             maxStageUnlocked = 4;
@@ -5386,7 +5400,17 @@
 
         if (currentLevel + 1 < levels.length && levels[currentLevel + 1].stage === 4) {
           currentLevel = levels.length;
-          showWinScreen();
+          challengeOfColorsBeaten = true;
+          localStorage.setItem('challengeOfColorsBeaten', 'true');
+          extraChallengesUnlocked = true;
+          localStorage.setItem('extraChallengesUnlocked', 'true');
+          maxStageUnlocked = 4;
+          const lastIndex = levels.length - 1;
+          if (maxUnlockedLevel < lastIndex) {
+            maxUnlockedLevel = lastIndex;
+            localStorage.setItem('maxUnlockedLevel', maxUnlockedLevel);
+          }
+          showWinScreen(null, true);
           return;
         }
 
@@ -5618,6 +5642,16 @@
       toggleMusic.checked = settings.music;
       toggleLightMode.checked = settings.lightMode;
       updateStarProgress();
+
+      if (challengeOfColorsBeaten) {
+        extraChallengesUnlocked = true;
+        maxStageUnlocked = 4;
+        const lastIndex = levels.length - 1;
+        if (maxUnlockedLevel < lastIndex) {
+          maxUnlockedLevel = lastIndex;
+          localStorage.setItem('maxUnlockedLevel', maxUnlockedLevel);
+        }
+      }
 
       if (extraChallengesUnlocked) {
         goChallengesButton.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- adjust win screen to show extra challenge unlock message
- add `challengeOfColorsBeaten` flag and unlock extra challenges when color challenge beaten
- revise Bullet Hell spawn behavior
- unlock Bullet Hell when color challenge is completed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886380babcc8325bd0d6c6c113e5778