### PR TITLE
Add spam space ability to Three Colors challenge

### DIFF
--- a/index.html
+++ b/index.html
@@ -786,6 +786,11 @@
       let spacePressTimes = [];
       let lastSpamColorChange = 0;
 
+      function getRandomThreeColorSpeed() {
+        const pool = [1, 2, 3, 4];
+        return pool[Math.floor(Math.random() * pool.length)];
+      }
+
       function getUniqueThreeColorSpeed() {
         const used = new Set(threeColorLines.map(l => l.speed));
         const pool = [1, 2, 3, 4].filter(s => !used.has(s));
@@ -2350,9 +2355,15 @@
         cube.x = lvl.spawn.x * canvas.width;
         cube.y = lvl.spawn.y * canvas.height;
 
-        const extraMsg = document.getElementById("extraColorMessage");
-        if (lvl.extracolor) extraMsg.classList.remove("hidden");
-        else extraMsg.classList.add("hidden");
+       const extraMsg = document.getElementById("extraColorMessage");
+       if (lvl.extracolor) extraMsg.classList.remove("hidden");
+       else extraMsg.classList.add("hidden");
+
+        // Reset spam space ability and hide the prompt
+        spamAbilityUnlocked = false;
+        spamActive = false;
+        spacePressTimes = [];
+        document.getElementById("spamSpaceMessage").classList.add("hidden");
 
         cube.vx = 0;
         cube.vy = 0;
@@ -4793,13 +4804,14 @@
           else if (pct >= 0.9) spawnInterval = 100; // final 10%
           const availableColors = threeColorUnlocked ? ["cyan","yellow","red"] : ["cyan","yellow"];
           if (spawnInterval && now - lastThreeColorSpawn >= spawnInterval) {
-            const speed = getUniqueThreeColorSpeed();
+            const speed = pct >= 0.9 ? getRandomThreeColorSpeed() : getUniqueThreeColorSpeed();
             if (speed !== null) {
               const color = availableColors[Math.floor(Math.random() * availableColors.length)];
               const thickness = 20;
               const side = Math.floor(Math.random() * 4);
               let line = { x:0, y:0, width:0, height:0, vx:0, vy:0, color, speed };
-              const vel = threeColorSpeedMap[speed];
+              let vel = threeColorSpeedMap[speed];
+              if (pct >= 0.9) vel *= 2;
               if (side === 0) { line.x=0; line.y=-thickness; line.width=canvas.width; line.height=thickness; line.vy=vel; }
               else if (side === 1) { line.x=0; line.y=canvas.height; line.width=canvas.width; line.height=thickness; line.vy=-vel; }
               else if (side === 2) { line.x=-thickness; line.y=0; line.width=thickness; line.height=canvas.height; line.vx=vel; }
@@ -5553,6 +5565,11 @@
       goChallengesButton.addEventListener("click", showChallenges);
 
       function levelComplete() {
+        // Hide spam prompt and reset spam state
+        document.getElementById("spamSpaceMessage").classList.add("hidden");
+        spamAbilityUnlocked = false;
+        spamActive = false;
+        spacePressTimes = [];
         if (levels[currentLevel].stage === 4) {
           winSound.currentTime = 0;
           winSound.play();

--- a/index.html
+++ b/index.html
@@ -205,6 +205,19 @@
         pointer-events: none;
       }
 
+      #spamSpaceMessage {
+        position: absolute;
+        top: 10px;
+        left: 0;
+        width: 100%;
+        text-align: center;
+        font-size: 48px;
+        font-family: "Press Start 2P", monospace;
+        color: white;
+        z-index: 50;
+        pointer-events: none;
+      }
+
       #starProgress.gold {
         color: gold;
       }
@@ -360,6 +373,7 @@
     <div id="checkpointPopup" class="overlay hidden">Checkpoint Reached</div>
     <div id="autoColorMessage" class="hidden">automatic color switching unlocked</div>
     <div id="extraColorMessage" class="hidden">New Color Unlocked</div>
+    <div id="spamSpaceMessage" class="hidden">SPAM SPACE AS FAST AS YOU CAN</div>
 
     <!-- ======================================================
          JavaScript Section: Contains all game logic and functionality.
@@ -766,6 +780,11 @@
       let threeColorUnlocked = false;
       let threeColorCheckpoint = false;
       const threeColorSpeedMap = {1: 1.7, 2: 1.8, 3: 1.9, 4: 2};
+
+      let spamAbilityUnlocked = false;
+      let spamActive = false;
+      let spacePressTimes = [];
+      let lastSpamColorChange = 0;
 
       function getUniqueThreeColorSpeed() {
         const used = new Set(threeColorLines.map(l => l.speed));
@@ -2968,6 +2987,9 @@
       // 10. Key Handling (No Diagonals) + Special Keys for Level Selector, Clear Storage, and "R" to die
       // -------------------------------------------------
       document.addEventListener("keydown", e => {
+        if (e.key === " " && spamAbilityUnlocked) {
+          spacePressTimes.push(Date.now());
+        }
         if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
           autoColorBuffer += e.key.toLowerCase();
           if (!autoColorCode.startsWith(autoColorBuffer)) {
@@ -3343,6 +3365,18 @@
       function update() {
         if (gamePaused) return;
         const now = Date.now();
+        if (spamAbilityUnlocked) {
+          spacePressTimes = spacePressTimes.filter(t => now - t <= 1000);
+          spamActive = spacePressTimes.length >= 3;
+          if (spamActive && now - lastSpamColorChange >= 50) {
+            if (outlineColor === "cyan") outlineColor = "yellow";
+            else if (outlineColor === "yellow") outlineColor = "red";
+            else outlineColor = "cyan";
+            lastSpamColorChange = now;
+          }
+        } else {
+          spamActive = false;
+        }
         let obstacles = [...platforms, ...browns, ...lifts];
         if (levels[currentLevel].fallingBrownLevel) {
           obstacles = obstacles.concat(fallingBrownBlocks);
@@ -4718,6 +4752,12 @@
         // Handle Three Colors challenge logic
         if (levels[currentLevel].threeColorsChallenge) {
           const pct = chargeProgress / chargeDuration;
+          const spamMsg = document.getElementById("spamSpaceMessage");
+          if (pct >= 0.85) spamMsg.classList.remove("hidden");
+          else spamMsg.classList.add("hidden");
+          if (!spamAbilityUnlocked && pct >= 0.86) {
+            spamAbilityUnlocked = true;
+          }
           if (!threeColorRedSpawned && pct >= 0.25) {
             const thickness = 20;
             const speed = 1;
@@ -4750,7 +4790,7 @@
           else if (pct >= 0.33 && pct < 0.5) spawnInterval = 2250; // 20–50%
           else if (pct >= 0.5 && pct < 0.75) spawnInterval = 1750;  // 50–75%
           else if (pct >= 0.75 && pct < 0.9) spawnInterval = 1250; // 75–90%
-          else if (pct >= 0.9) spawnInterval = 1000; // final 10%
+          else if (pct >= 0.9) spawnInterval = 100; // final 10%
           const availableColors = threeColorUnlocked ? ["cyan","yellow","red"] : ["cyan","yellow"];
           if (spawnInterval && now - lastThreeColorSpawn >= spawnInterval) {
             const speed = getUniqueThreeColorSpeed();
@@ -4778,7 +4818,7 @@
             }
             let rect = { x: l.x, y: l.y, width: l.width, height: l.height };
             if (rectIntersect(cubeRect, rect)) {
-              if (outlineColor !== l.color) {
+              if (!spamActive && outlineColor !== l.color) {
                 deathSound.currentTime = 0;
                 deathSound.play();
                 loadLevel(currentLevel);


### PR DESCRIPTION
## Summary
- add `spamSpaceMessage` overlay and styling
- implement new spam ability variables and key tracking
- unlock ability at 86% progress in Three Colors challenge
- show prompt to spam space near the end and spawn lines faster
- allow rapid space presses to cycle colors and ignore line collisions

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688664f59abc83259a8be9f17217980b