### PR TITLE
Add Challenge of 2 extra level

### DIFF
--- a/index.html
+++ b/index.html
@@ -707,7 +707,8 @@
       //  NEW GLOBALS FOR THE CHALLENGE LEVEL (after level 17)
       // -------------------------------------------------
       let challengeStartTime = 0; // When the challenge level starts
-      const challengeDuration = 30000; // Duration of the challenge in milliseconds (30 seconds)
+      const defaultChallengeDuration = 30000; // Default challenge duration (30 seconds)
+      let currentChallengeDuration = defaultChallengeDuration;
       let lastChallengeLineSpawn = 0; // Timestamp for last spawned challenge line
       let challengeLines = []; // Array to store moving challenge line objects
       // Challenge lines move at 40% of level 15’s orange block speed.
@@ -773,6 +774,8 @@
       let bulletHellStartTime = 0;
       let bulletHellLastSpawn = 0;
       let bulletHellBlocks = [];
+      // Globals for Challenge of 2
+      let challengeTwoMessageTime = 0;
       // Globals for the Three Colors challenge
       let threeColorLines = [];
       let lastThreeColorSpawn = 0;
@@ -796,6 +799,143 @@
         const pool = [1, 2, 3, 4].filter(s => !used.has(s));
         if (pool.length === 0) return null;
         return pool[Math.floor(Math.random() * pool.length)];
+      }
+
+      // -------------------------------------------------
+      // Challenge of 2 Update Logic
+      // -------------------------------------------------
+      function updateChallengeTwo(now) {
+        const accelScale = 0.5;
+        // Update movement for both cubes
+        const players = [
+          { cube: cube, dir: lastDirection, ax: arrowDirX, ay: arrowDirY },
+          { cube: cube2, dir: lastDirection2, ax: arrowDirX2, ay: arrowDirY2 }
+        ];
+
+        players.forEach((p, idx) => {
+          const c = p.cube;
+          let dir = p.dir;
+          if (dir === "up") {
+            c.vy -= currentAcceleration * accelScale;
+            c.vx = 0;
+            if (idx === 0) { arrowDirX = 0; arrowDirY = -1; }
+            else { arrowDirX2 = 0; arrowDirY2 = -1; }
+          } else if (dir === "down") {
+            c.vy += currentAcceleration * accelScale;
+            c.vx = 0;
+            if (idx === 0) { arrowDirX = 0; arrowDirY = 1; }
+            else { arrowDirX2 = 0; arrowDirY2 = 1; }
+          } else if (dir === "left") {
+            c.vx -= currentAcceleration * accelScale;
+            c.vy = 0;
+            if (idx === 0) { arrowDirX = -1; arrowDirY = 0; }
+            else { arrowDirX2 = -1; arrowDirY2 = 0; }
+          } else if (dir === "right") {
+            c.vx += currentAcceleration * accelScale;
+            c.vy = 0;
+            if (idx === 0) { arrowDirX = 1; arrowDirY = 0; }
+            else { arrowDirX2 = 1; arrowDirY2 = 0; }
+          }
+          c.vx *= 0.88;
+          c.vy *= 0.88;
+          c.x += c.vx;
+          c.y += c.vy;
+          if (c.x - c.size / 2 < 0) { c.x = c.size / 2; c.vx = 0; }
+          else if (c.x + c.size / 2 > canvas.width) { c.x = canvas.width - c.size / 2; c.vx = 0; }
+          if (c.y - c.size / 2 < 0) { c.y = c.size / 2; c.vy = 0; }
+          else if (c.y + c.size / 2 > canvas.height) { c.y = canvas.height - c.size / 2; c.vy = 0; }
+        });
+
+        // === Pause handling ===
+        if (!document.hidden && !gamePaused) {
+          if (isChallengePaused) {
+            challengePausedTime += (now - lastChallengePauseStart);
+            isChallengePaused = false;
+          }
+        } else {
+          if (!isChallengePaused) {
+            isChallengePaused = true;
+            lastChallengePauseStart = now;
+          }
+        }
+
+        let elapsed = (now - challengeStartTime) - challengePausedTime;
+        let remaining = currentChallengeDuration - elapsed;
+
+        let spawnInterval = 3500;
+        if (remaining <= 22500 && remaining > 18500) {
+          spawnInterval = 2500;
+        } else if (remaining <= 18500 && remaining > 15000) {
+          spawnInterval = 2000;
+        } else if (remaining <= 15000 && remaining > 5000) {
+          spawnInterval = 1500;
+        } else if (remaining <= 5000) {
+          spawnInterval = 1250;
+        }
+
+        if (now - lastChallengeLineSpawn >= spawnInterval) {
+          const directions = ["up","down","left","right"];
+          const dir = directions[Math.floor(Math.random()*directions.length)];
+          const lineThickness = 20;
+          let line = { direction: dir, vx:0, vy:0, x:0, y:0, width:0, height:0 };
+          if (dir === "up") { line.x = Math.random()*(canvas.width-lineThickness); line.y=-canvas.height; line.width=lineThickness; line.height=canvas.height; line.vy=challengeLineSpeed; }
+          else if (dir === "down") { line.x=Math.random()*(canvas.width-lineThickness); line.y=canvas.height; line.width=lineThickness; line.height=canvas.height; line.vy=-challengeLineSpeed; }
+          else if (dir === "left") { line.y=Math.random()*(canvas.height-lineThickness); line.x=-canvas.width; line.width=canvas.width; line.height=lineThickness; line.vx=challengeLineSpeed; }
+          else { line.y=Math.random()*(canvas.height-lineThickness); line.x=canvas.width; line.width=canvas.width; line.height=lineThickness; line.vx=-challengeLineSpeed; }
+          challengeLines.push(line);
+          lastChallengeLineSpawn = now;
+        }
+
+        for (let i = challengeLines.length - 1; i >= 0; i--) {
+          let line = challengeLines[i];
+          line.x += line.vx;
+          line.y += line.vy;
+          if (line.direction === "up" && line.y > canvas.height) challengeLines.splice(i,1);
+          else if (line.direction === "down" && line.y + line.height < 0) challengeLines.splice(i,1);
+          else if (line.direction === "left" && line.x > canvas.width) challengeLines.splice(i,1);
+          else if (line.direction === "right" && line.x + line.width < 0) challengeLines.splice(i,1);
+        }
+
+        if (now >= fallingRedTextStart + 750 && now - lastRedSpawnTime >= 750) {
+          fallingRedBlocks.push({ x: Math.random()*(canvas.width - cube.size), y:-cube.size, width:cube.size, height:cube.size, baseVy:2, vy:2, spawnTime:now });
+          lastRedSpawnTime = now;
+        }
+        for (let i = fallingRedBlocks.length -1; i >=0; i--) {
+          let block = fallingRedBlocks[i];
+          block.y += block.vy;
+          if (block.y > canvas.height) { fallingRedBlocks.splice(i,1); continue; }
+          const rect = { x:block.x, y:block.y, width:block.width, height:block.height };
+          const rect1 = { x:cube.x - cube.size/2, y:cube.y - cube.size/2, width:cube.size, height:cube.size };
+          const rect2 = { x:cube2.x - cube2.size/2, y:cube2.y - cube2.size/2, width:cube2.size, height:cube2.size };
+          if (rectIntersect(rect1, rect) || rectIntersect(rect2, rect)) {
+            deathSound.currentTime = 0; deathSound.play(); loadLevel(currentLevel); return;
+          }
+        }
+
+        if (challengePhase === 3 && remaining <= 0 && !challengeGreenBlock) {
+          challengeGreenBlock = { x: canvas.width/2, y: canvas.height/2, size: cube.size * 30 };
+        }
+
+        const lineRects = challengeLines.map(l => ({x:l.x, y:l.y, width:l.width, height:l.height}));
+        const playersRects = [
+          { x:cube.x - cube.size/2, y:cube.y - cube.size/2, width:cube.size, height:cube.size },
+          { x:cube2.x - cube2.size/2, y:cube2.y - cube2.size/2, width:cube2.size, height:cube2.size }
+        ];
+        for (let lr of lineRects) {
+          for (let pr of playersRects) {
+            if (rectIntersect(lr, pr)) {
+              deathSound.currentTime = 0; deathSound.play(); loadLevel(currentLevel); return;
+            }
+          }
+        }
+
+        if (challengeGreenBlock) {
+          let gRect = { x:challengeGreenBlock.x - challengeGreenBlock.size/2, y:challengeGreenBlock.y - challengeGreenBlock.size/2, width:challengeGreenBlock.size, height:challengeGreenBlock.size };
+          if (rectIntersect(gRect, playersRects[0]) || rectIntersect(gRect, playersRects[1])) {
+            levelComplete();
+            return;
+          }
+        }
       }
       // Timeout handle for the delayed hazard in Stage 3 Level 3
       let stage3Level3HazardTimeout = null;
@@ -926,17 +1066,27 @@
       // -------------------------------------------------
       // 2. Player (Cube) + Movement (No Diagonals)
       // -------------------------------------------------
-      // Define the player cube with initial properties
+      // Define the player cubes with initial properties
+      const baseCubeSize = 80;
       const cube = {
         x: 0,
         y: 0,
-        size: 80,
+        size: baseCubeSize,
+        vx: 0,
+        vy: 0
+      };
+      // Second player cube, used only in the Challenge of 2
+      const cube2 = {
+        x: 0,
+        y: 0,
+        size: baseCubeSize,
         vx: 0,
         vy: 0
       };
 
       // Variable to store the last movement direction to prevent diagonal movement
       let lastDirection = null;
+      let lastDirection2 = null;
 
       // -------------------------------------------------
       // 3. Dash and Teleport Gimmicks
@@ -957,6 +1107,8 @@
       // -------------------------------------------------
       let arrowDirX = 0;
       let arrowDirY = -1;
+      let arrowDirX2 = 0;
+      let arrowDirY2 = -1;
 
       // -------------------------------------------------
       // 5. Display Cooldown (Displayed at the Top-Left Corner)
@@ -2230,7 +2382,7 @@
           platforms: [],
           hazards: []
         },
-        {
+        { 
           // -------------------------------------------------
           // EXTRA CHALLENGE: Three Colors
           // -------------------------------------------------
@@ -2244,6 +2396,18 @@
           noMovement: true,
           stage: 4,
           challengeName: "Three Colors",
+          platforms: [],
+          hazards: []
+        },
+        {
+          // -------------------------------------------------
+          // EXTRA CHALLENGE: Challenge of 2
+          // -------------------------------------------------
+          spawn: { x: 0.5, y: 0.5 },
+          challengeTwo: true,
+          stage: 4,
+          challengeName: "Challenge of 2",
+          noDash: true,
           platforms: [],
           hazards: []
         }
@@ -2305,6 +2469,9 @@
         currentLevel = index;
         updateUnlockedProgress();
         const lvl = levels[index];
+        currentChallengeDuration = defaultChallengeDuration;
+        cube.size = baseCubeSize;
+        cube2.size = baseCubeSize;
 
         if (lvl.stage === 4) {
           if (currentMode !== "normal") {
@@ -2476,6 +2643,32 @@
           bulletHellLastSpawn = bulletHellStartTime;
           bulletHellBlocks = [];
           challengeGreenBlock = null;
+          challengePausedTime = 0;
+          isChallengePaused = false;
+          lastChallengePauseStart = 0;
+        } else if (lvl.challengeTwo) {
+          target = null;
+          currentChallengeDuration = 45000;
+          challengeStartTime = Date.now();
+          lastChallengeLineSpawn = Date.now();
+          challengeLines = [];
+          fallingRedBlocks = [];
+          challengeGreenBlock = null;
+          challengePhase = 3;
+          cube.size = baseCubeSize / 2;
+          cube2.size = baseCubeSize / 2;
+          cube.x = canvas.width / 2 + cube.size;
+          cube.y = canvas.height / 2;
+          cube.vx = cube.vy = 0;
+          arrowDirX = 0;
+          arrowDirY = -1;
+          lastDirection = null;
+          cube2.x = canvas.width / 2 - cube2.size;
+          cube2.y = canvas.height / 2;
+          cube2.vx = cube2.vy = 0;
+          arrowDirX2 = 0;
+          arrowDirY2 = -1;
+          lastDirection2 = null;
           challengePausedTime = 0;
           isChallengePaused = false;
           lastChallengePauseStart = 0;
@@ -3120,6 +3313,22 @@
             case "ArrowRight":
               lastDirection = "right";
               break;
+            case "w":
+            case "W":
+              lastDirection2 = "up";
+              break;
+            case "s":
+            case "S":
+              lastDirection2 = "down";
+              break;
+            case "a":
+            case "A":
+              lastDirection2 = "left";
+              break;
+            case "d":
+            case "D":
+              lastDirection2 = "right";
+              break;
           }
         }
       });
@@ -3376,6 +3585,10 @@
       function update() {
         if (gamePaused) return;
         const now = Date.now();
+        if (levels[currentLevel].challengeTwo) {
+          updateChallengeTwo(now);
+          return;
+        }
         if (spamAbilityUnlocked) {
           spacePressTimes = spacePressTimes.filter(t => now - t <= 1000);
           spamActive = spacePressTimes.length >= 3;
@@ -4243,7 +4456,7 @@
           // Instead of just "now - challengeStartTime", we subtract challengePausedTime
           let rawElapsed = now - challengeStartTime;
           let elapsed = rawElapsed - challengePausedTime;
-          let remaining = challengeDuration - elapsed;
+          let remaining = currentChallengeDuration - elapsed;
 
           let spawnInterval = 3500;
           if (remaining <= 22500 && remaining > 18500) {
@@ -4399,7 +4612,7 @@
           }
 
           let elapsed = (now - challengeStartTime) - challengePausedTime;
-          let remaining = challengeDuration - elapsed;
+          let remaining = currentChallengeDuration - elapsed;
 
           // When the timer expires during phase 3, spawn the green block
           if (challengePhase === 3 && remaining <= 0 && !challengeGreenBlock) {
@@ -4593,7 +4806,7 @@
             }
           }
 
-          if ((challengePhase === 1 || challengePhase === 2) && elapsed >= challengeDuration && !challengeWhiteBlock) {
+          if ((challengePhase === 1 || challengePhase === 2) && elapsed >= currentChallengeDuration && !challengeWhiteBlock) {
             challengeWhiteBlock = { x: canvas.width / 2, y: canvas.height / 2, size: 200 };
           }
 
@@ -5068,7 +5281,7 @@
         }
       }
       function drawFallingRedBlocks() {
-        if (levels[currentLevel].challengeDashingLevel ||
+        if (levels[currentLevel].challengeDashingLevel || levels[currentLevel].challengeTwo ||
             (levels[currentLevel].challengeTeleportLevel && challengePhase >= 2)) {
           ctx.fillStyle = levels[currentLevel].challengeTeleportLevel ? "purple" : "red";
           for (let block of fallingRedBlocks) {
@@ -5085,8 +5298,8 @@
         }
       }
       function drawChallengeLines() {
-        if (levels[currentLevel].challengeDashingLevel) {
-          ctx.fillStyle = "orange";
+        if (levels[currentLevel].challengeDashingLevel || levels[currentLevel].challengeTwo) {
+          ctx.fillStyle = levels[currentLevel].challengeTwo ? "red" : "orange";
           for (let line of challengeLines) {
             ctx.fillRect(line.x, line.y, line.width, line.height);
           }
@@ -5172,7 +5385,7 @@
         if (levels[currentLevel].challengeDashingLevel) {
           ctx.fillText("Challenge Of Dashing", 10, 40);
           let elapsed = Date.now() - challengeStartTime - challengePausedTime;
-          let remainingSec = Math.max(0, Math.ceil((challengeDuration - elapsed) / 1000));
+          let remainingSec = Math.max(0, Math.ceil((currentChallengeDuration - elapsed) / 1000));
           ctx.textAlign = "center";
           ctx.fillText(remainingSec + "s", canvas.width / 2, 40);
           ctx.textAlign = "left";
@@ -5185,7 +5398,7 @@
             ctx.fillText("Challenge Of Teleportation 1/3", 10, 40);
           }
           let elapsed = Date.now() - challengeStartTime - challengePausedTime;
-          let remainingSec = Math.max(0, Math.ceil((challengeDuration - elapsed) / 1000));
+          let remainingSec = Math.max(0, Math.ceil((currentChallengeDuration - elapsed) / 1000));
           ctx.textAlign = "center";
           ctx.fillText(remainingSec + "s", canvas.width / 2, 40);
           ctx.textAlign = "left";
@@ -5205,6 +5418,16 @@
           let remainingSec = Math.max(0, Math.ceil((bulletHellDuration - elapsed) / 1000));
           ctx.textAlign = "center";
           ctx.fillText(remainingSec + "s", canvas.width / 2, 40);
+          ctx.textAlign = "left";
+        } else if (levels[currentLevel].challengeTwo) {
+          ctx.fillText("Challenge of 2", 10, 40);
+          let elapsed = Date.now() - challengeStartTime - challengePausedTime;
+          let remainingSec = Math.max(0, Math.ceil((currentChallengeDuration - elapsed) / 1000));
+          ctx.textAlign = "center";
+          ctx.fillText(remainingSec + "s", canvas.width / 2, 40);
+          if (elapsed < 4000) {
+            ctx.fillText("Control The Green Arrow with WASD, control the red arrow with Arrow Keys", canvas.width / 2, 80);
+          }
           ctx.textAlign = "left";
         } else {
           let stage = levels[currentLevel].stage || 1;
@@ -5295,6 +5518,40 @@
         ctx.closePath();
         ctx.fill();
       }
+
+      function drawCubeCustom(obj, dirX, dirY, arrowColor) {
+        ctx.fillStyle = "#fff";
+        ctx.fillRect(obj.x - obj.size / 2, obj.y - obj.size / 2, obj.size, obj.size);
+        ctx.fillStyle = arrowColor;
+        let mag = Math.hypot(dirX, dirY);
+        let uX = dirX, uY = dirY;
+        if (mag === 0) { uX = 0; uY = -1; }
+        const angle = Math.atan2(uY, uX);
+        const a = obj.size * 0.3;
+        const b = obj.size * 0.15;
+        const cVal = obj.size * 0.3;
+        function rotPt(x, y, ang) {
+          return { x: x * Math.cos(ang) - y * Math.sin(ang), y: x * Math.sin(ang) + y * Math.cos(ang) };
+        }
+        let tipLocal = { x: a, y: 0 };
+        let baseLeft = { x: -b, y: cVal };
+        let baseRight = { x: -b, y: -cVal };
+        let tipRot = rotPt(tipLocal.x, tipLocal.y, angle);
+        let blRot = rotPt(baseLeft.x, baseLeft.y, angle);
+        let brRot = rotPt(baseRight.x, baseRight.y, angle);
+        const tipX = obj.x + tipRot.x;
+        const tipY = obj.y + tipRot.y;
+        const blX  = obj.x + blRot.x;
+        const blY  = obj.y + blRot.y;
+        const brX  = obj.x + brRot.x;
+        const brY  = obj.y + brRot.y;
+        ctx.beginPath();
+        ctx.moveTo(tipX, tipY);
+        ctx.lineTo(blX, blY);
+        ctx.lineTo(brX, brY);
+        ctx.closePath();
+        ctx.fill();
+      }
       function spawnLevel13Pillars() {
         level13PillarsSpawned = true;
         const speedMult = levels[currentLevel].halfSpeedPillars ? .8 : 1;
@@ -5372,7 +5629,12 @@
           drawChallengeGreyBlocks();
           drawChallengeTeleportLines();
         }
-        drawCube();
+        if (levels[currentLevel].challengeTwo) {
+          drawCubeCustom(cube2, arrowDirX2, arrowDirY2, "green");
+          drawCubeCustom(cube, arrowDirX, arrowDirY, "red");
+        } else {
+          drawCube();
+        }
         drawBrownParticles();
         drawGreyParticles();
         drawLevelText();


### PR DESCRIPTION
## Summary
- add new extra challenge "Challenge of 2"
- spawn two smaller players with separate controls
- show instructional text for first 4 seconds
- use per-level challenge duration
- draw additional cube and red challenge lines

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886862e70e8832585967db33038b7fb