### PR TITLE
Add Challenge of 2 extra challenge

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,6 +218,19 @@
         pointer-events: none;
       }
 
+      #dualControlMessage {
+        position: absolute;
+        top: 10px;
+        left: 0;
+        width: 100%;
+        text-align: center;
+        font-size: 48px;
+        font-family: "Press Start 2P", monospace;
+        color: white;
+        z-index: 50;
+        pointer-events: none;
+      }
+
       #starProgress.gold {
         color: gold;
       }
@@ -374,6 +387,7 @@
     <div id="autoColorMessage" class="hidden">automatic color switching unlocked</div>
     <div id="extraColorMessage" class="hidden">New Color Unlocked</div>
     <div id="spamSpaceMessage" class="hidden">SPAM SPACE AS FAST AS YOU CAN</div>
+    <div id="dualControlMessage" class="hidden">Control The Green Arrow with WASD, control the red arrow with Arrow Keys</div>
 
     <!-- ======================================================
          JavaScript Section: Contains all game logic and functionality.
@@ -773,6 +787,8 @@
       let bulletHellStartTime = 0;
       let bulletHellLastSpawn = 0;
       let bulletHellBlocks = [];
+      // Globals for Challenge of 2
+      const challengeTwoDuration = 45000; // 45 seconds
       // Globals for the Three Colors challenge
       let threeColorLines = [];
       let lastThreeColorSpawn = 0;
@@ -926,17 +942,26 @@
       // -------------------------------------------------
       // 2. Player (Cube) + Movement (No Diagonals)
       // -------------------------------------------------
-      // Define the player cube with initial properties
+      // Define the base cube size and player cubes (second cube used only in Challenge of 2)
+      const baseCubeSize = 80;
       const cube = {
         x: 0,
         y: 0,
-        size: 80,
+        size: baseCubeSize,
+        vx: 0,
+        vy: 0
+      };
+      const cube2 = {
+        x: 0,
+        y: 0,
+        size: baseCubeSize,
         vx: 0,
         vy: 0
       };
 
-      // Variable to store the last movement direction to prevent diagonal movement
+      // Variables to store the last movement direction to prevent diagonal movement
       let lastDirection = null;
+      let lastDirection2 = null;
 
       // -------------------------------------------------
       // 3. Dash and Teleport Gimmicks
@@ -957,6 +982,8 @@
       // -------------------------------------------------
       let arrowDirX = 0;
       let arrowDirY = -1;
+      let arrowDirX2 = 0;
+      let arrowDirY2 = -1;
 
       // -------------------------------------------------
       // 5. Display Cooldown (Displayed at the Top-Left Corner)
@@ -2232,6 +2259,20 @@
         },
         {
           // -------------------------------------------------
+          // EXTRA CHALLENGE: Challenge of 2
+          // -------------------------------------------------
+          spawn: { x: 0.47, y: 0.5 },
+          spawn2: { x: 0.53, y: 0.5 },
+          challengeDashingLevel: true,
+          challengeTwoLevel: true,
+          stage: 4,
+          challengeName: "Challenge of 2",
+          noDash: true,
+          platforms: [],
+          hazards: []
+        },
+        {
+          // -------------------------------------------------
           // EXTRA CHALLENGE: Three Colors
           // -------------------------------------------------
           spawn: { x: 0.5, y: 0.5 },
@@ -2351,9 +2392,13 @@
         if (lvl.threeColorsChallenge && prevLevel !== index) {
           threeColorCheckpoint = false;
         }
-        document.getElementById("checkpointPopup").classList.add("hidden");
-        cube.x = lvl.spawn.x * canvas.width;
-        cube.y = lvl.spawn.y * canvas.height;
+       document.getElementById("checkpointPopup").classList.add("hidden");
+       cube.x = lvl.spawn.x * canvas.width;
+       cube.y = lvl.spawn.y * canvas.height;
+       cube.size = baseCubeSize;
+       cube2.size = baseCubeSize;
+       cube2.x = cube.x;
+       cube2.y = cube.y;
 
        const extraMsg = document.getElementById("extraColorMessage");
        if (lvl.extracolor) extraMsg.classList.remove("hidden");
@@ -2416,6 +2461,31 @@
           challengePausedTime = 0;
           isChallengePaused = false;
           lastChallengePauseStart = 0;
+        } else if (lvl.challengeTwoLevel) {
+          target = null;
+          challengeStartTime = Date.now();
+          lastChallengeLineSpawn = Date.now();
+          challengeLines = [];
+          fallingRedBlocks = [];
+          fallingRedTextStart = Date.now();
+          lastRedSpawnTime = Date.now();
+          challengeGreenBlock = null;
+          challengePhase = 3;
+          challengePausedTime = 0;
+          isChallengePaused = false;
+          lastChallengePauseStart = 0;
+          cube.size = baseCubeSize / 2;
+          cube2.size = baseCubeSize / 2;
+          cube.x = lvl.spawn.x * canvas.width;
+          cube.y = lvl.spawn.y * canvas.height;
+          cube2.x = lvl.spawn2.x * canvas.width;
+          cube2.y = lvl.spawn2.y * canvas.height;
+          cube.vx = cube.vy = 0;
+          cube2.vx = cube2.vy = 0;
+          arrowDirX = 0; arrowDirY = -1;
+          arrowDirX2 = 0; arrowDirY2 = -1;
+          lastDirection = null;
+          lastDirection2 = null;
         } else if (lvl.challengeTeleportLevel) {
             target = null;
             challengeStartTime = Date.now();
@@ -3107,19 +3177,32 @@
         else if (!levels[currentLevel].noMovement && currentLevel >= 7 && e.key === " " && !isDashing && !levels[currentLevel].noDash) {
           attemptDash();
         } else if (!levels[currentLevel].noMovement) {
-          switch (e.key) {
-            case "ArrowUp":
-              lastDirection = "up";
-              break;
-            case "ArrowDown":
-              lastDirection = "down";
-              break;
-            case "ArrowLeft":
-              lastDirection = "left";
-              break;
-            case "ArrowRight":
-              lastDirection = "right";
-              break;
+          if (levels[currentLevel].challengeTwoLevel) {
+            switch (e.key) {
+              case "ArrowUp": lastDirection2 = "up"; break;
+              case "ArrowDown": lastDirection2 = "down"; break;
+              case "ArrowLeft": lastDirection2 = "left"; break;
+              case "ArrowRight": lastDirection2 = "right"; break;
+              case "w": case "W": lastDirection = "up"; break;
+              case "s": case "S": lastDirection = "down"; break;
+              case "a": case "A": lastDirection = "left"; break;
+              case "d": case "D": lastDirection = "right"; break;
+            }
+          } else {
+            switch (e.key) {
+              case "ArrowUp":
+                lastDirection = "up";
+                break;
+              case "ArrowDown":
+                lastDirection = "down";
+                break;
+              case "ArrowLeft":
+                lastDirection = "left";
+                break;
+              case "ArrowRight":
+                lastDirection = "right";
+                break;
+            }
           }
         }
       });
@@ -5086,7 +5169,7 @@
       }
       function drawChallengeLines() {
         if (levels[currentLevel].challengeDashingLevel) {
-          ctx.fillStyle = "orange";
+          ctx.fillStyle = levels[currentLevel].challengeTwoLevel ? "red" : "orange";
           for (let line of challengeLines) {
             ctx.fillRect(line.x, line.y, line.width, line.height);
           }
@@ -5144,6 +5227,7 @@
       function drawChallengeGreenBlock() {
         if ((levels[currentLevel].challengeDashingLevel ||
              levels[currentLevel].challengeBulletHell ||
+             levels[currentLevel].challengeTwoLevel ||
              (levels[currentLevel].challengeTeleportLevel && challengePhase === 3)) && challengeGreenBlock) {
           ctx.fillStyle = "green";
           ctx.fillRect(
@@ -5173,6 +5257,13 @@
           ctx.fillText("Challenge Of Dashing", 10, 40);
           let elapsed = Date.now() - challengeStartTime - challengePausedTime;
           let remainingSec = Math.max(0, Math.ceil((challengeDuration - elapsed) / 1000));
+          ctx.textAlign = "center";
+          ctx.fillText(remainingSec + "s", canvas.width / 2, 40);
+          ctx.textAlign = "left";
+        } else if (levels[currentLevel].challengeTwoLevel) {
+          ctx.fillText("Challenge of 2", 10, 40);
+          let elapsed = Date.now() - challengeStartTime - challengePausedTime;
+          let remainingSec = Math.max(0, Math.ceil((challengeTwoDuration - elapsed) / 1000));
           ctx.textAlign = "center";
           ctx.fillText(remainingSec + "s", canvas.width / 2, 40);
           ctx.textAlign = "left";
@@ -5295,6 +5386,36 @@
         ctx.closePath();
         ctx.fill();
       }
+
+      function drawCubeSimple(c, dirX, dirY, arrowColor) {
+        ctx.fillStyle = "#fff";
+        ctx.fillRect(c.x - c.size / 2, c.y - c.size / 2, c.size, c.size);
+        ctx.fillStyle = arrowColor;
+        let mag = Math.hypot(dirX, dirY);
+        let uX = dirX, uY = dirY;
+        if (mag === 0) { uX = 0; uY = -1; }
+        const angle = Math.atan2(uY, uX);
+        const a = c.size * 0.3;
+        const b = c.size * 0.15;
+        const cVal = c.size * 0.3;
+        function rotPt(x, y, ang) {
+          return { x: x * Math.cos(ang) - y * Math.sin(ang), y: x * Math.sin(ang) + y * Math.cos(ang) };
+        }
+        let tip = rotPt(a, 0, angle);
+        let bl = rotPt(-b, cVal, angle);
+        let br = rotPt(-b, -cVal, angle);
+        ctx.beginPath();
+        ctx.moveTo(c.x + tip.x, c.y + tip.y);
+        ctx.lineTo(c.x + bl.x, c.y + bl.y);
+        ctx.lineTo(c.x + br.x, c.y + br.y);
+        ctx.closePath();
+        ctx.fill();
+      }
+
+      function drawTwoCubes() {
+        drawCubeSimple(cube, arrowDirX, arrowDirY, "green");
+        drawCubeSimple(cube2, arrowDirX2, arrowDirY2, "red");
+      }
       function spawnLevel13Pillars() {
         level13PillarsSpawned = true;
         const speedMult = levels[currentLevel].halfSpeedPillars ? .8 : 1;
@@ -5318,6 +5439,111 @@
         };
         level13Pillars.push(verticalPillar);
         level13Pillars.push(horizontalPillar);
+      }
+
+      function updateChallengeTwo(now) {
+        const msg = document.getElementById("dualControlMessage");
+        if (now - challengeStartTime < 4000) msg.classList.remove("hidden");
+        else msg.classList.add("hidden");
+
+        let difficultyMultiplier = 1.0;
+        if (currentMode === "hard") difficultyMultiplier = 0.7;
+        else if (currentMode === "easy") difficultyMultiplier = 1.5;
+
+        if (!document.hidden && !gamePaused) {
+          if (isChallengePaused) {
+            challengePausedTime += (now - lastChallengePauseStart);
+            isChallengePaused = false;
+          }
+        } else {
+          if (!isChallengePaused) {
+            isChallengePaused = true;
+            lastChallengePauseStart = now;
+          }
+        }
+
+        let rawElapsed = now - challengeStartTime;
+        let elapsed = rawElapsed - challengePausedTime;
+        let remaining = challengeTwoDuration - elapsed;
+
+        let spawnInterval = 3500;
+        if (remaining <= 22500 && remaining > 18500) spawnInterval = 2500;
+        else if (remaining <= 18500 && remaining > 15000) spawnInterval = 2000;
+        else if (remaining <= 15000 && remaining > 5000) spawnInterval = 1500;
+        else if (remaining <= 5000) spawnInterval = 1250;
+        spawnInterval *= difficultyMultiplier;
+
+        if (now - lastChallengeLineSpawn >= spawnInterval) {
+          const directions = ["up","down","left","right"];
+          const dir = directions[Math.floor(Math.random()*directions.length)];
+          const thickness = 20;
+          let line = { direction: dir, vx:0, vy:0, x:0, y:0, width:0, height:0 };
+          if (dir === "up") { line.x=Math.random()*(canvas.width-thickness); line.y=-canvas.height; line.width=thickness; line.height=canvas.height; line.vy=challengeLineSpeed; }
+          else if (dir === "down") { line.x=Math.random()*(canvas.width-thickness); line.y=canvas.height; line.width=thickness; line.height=canvas.height; line.vy=-challengeLineSpeed; }
+          else if (dir === "left") { line.y=Math.random()*(canvas.height-thickness); line.x=-canvas.width; line.width=canvas.width; line.height=thickness; line.vx=challengeLineSpeed; }
+          else { line.y=Math.random()*(canvas.height-thickness); line.x=canvas.width; line.width=canvas.width; line.height=thickness; line.vx=-challengeLineSpeed; }
+          challengeLines.push(line);
+          lastChallengeLineSpawn = now;
+        }
+
+        for (let i = challengeLines.length-1; i>=0; i--) {
+          let l = challengeLines[i];
+          l.x += l.vx; l.y += l.vy;
+          if ((l.direction==="up" && l.y>canvas.height) || (l.direction==="down" && l.y+l.height<0) || (l.direction==="left" && l.x>canvas.width) || (l.direction==="right" && l.x+l.width<0)) {
+            challengeLines.splice(i,1);
+          }
+        }
+
+        if (now >= fallingRedTextStart + 750 * difficultyMultiplier && now - lastRedSpawnTime >= 750 * difficultyMultiplier) {
+          fallingRedBlocks.push({ x: Math.random() * (canvas.width - cube.size), y: -cube.size, width: cube.size, height: cube.size, baseVy:2, vy:2, spawnTime: now });
+          lastRedSpawnTime = now;
+        }
+        for (let i = fallingRedBlocks.length-1; i>=0; i--) {
+          let b = fallingRedBlocks[i];
+          b.y += b.vy;
+          if (b.y > canvas.height) { fallingRedBlocks.splice(i,1); continue; }
+        }
+
+        if (challengePhase === 3 && remaining <= 0 && !challengeGreenBlock) {
+          challengeGreenBlock = { x: canvas.width/2, y: canvas.height/2, size: cube.size * 30 };
+        }
+
+        function handlePlayer(p, dir, isFirst) {
+          if (levels[currentLevel].noMovement) { p.vx = 0; p.vy = 0; return; }
+          if (dir === "up") { p.vy -= currentAcceleration; p.vx = 0; if(isFirst){arrowDirX=0; arrowDirY=-1;} else {arrowDirX2=0; arrowDirY2=-1;} }
+          else if (dir === "down") { p.vy += currentAcceleration; p.vx = 0; if(isFirst){arrowDirX=0; arrowDirY=1;} else {arrowDirX2=0; arrowDirY2=1;} }
+          else if (dir === "left") { p.vx -= currentAcceleration; p.vy = 0; if(isFirst){arrowDirX=-1; arrowDirY=0;} else {arrowDirX2=-1; arrowDirY2=0;} }
+          else if (dir === "right") { p.vx += currentAcceleration; p.vy = 0; if(isFirst){arrowDirX=1; arrowDirY=0;} else {arrowDirX2=1; arrowDirY2=0;} }
+          p.vx *= 0.88; p.vy *= 0.88;
+          p.x += p.vx; p.y += p.vy;
+          if (p.x - p.size/2 < 0) { p.x = p.size/2; p.vx=0; }
+          else if (p.x + p.size/2 > canvas.width) { p.x = canvas.width - p.size/2; p.vx=0; }
+          if (p.y - p.size/2 < 0) { p.y = p.size/2; p.vy=0; }
+          else if (p.y + p.size/2 > canvas.height) { p.y = canvas.height - p.size/2; p.vy=0; }
+        }
+
+        handlePlayer(cube, lastDirection, true);
+        handlePlayer(cube2, lastDirection2, false);
+
+        function checkCollisions(p) {
+          const rect = { x: p.x - p.size/2, y: p.y - p.size/2, width: p.size, height: p.size };
+          for (let l of challengeLines) {
+            const lr = { x:l.x, y:l.y, width:l.width, height:l.height };
+            if (rectIntersect(rect, lr)) { deathSound.currentTime=0; deathSound.play(); loadLevel(currentLevel); return true; }
+          }
+          for (let b of fallingRedBlocks) {
+            const br = { x:b.x, y:b.y, width:b.width, height:b.height };
+            if (rectIntersect(rect, br)) { deathSound.currentTime=0; deathSound.play(); loadLevel(currentLevel); return true; }
+          }
+          if (challengeGreenBlock) {
+            const gr = { x: challengeGreenBlock.x - challengeGreenBlock.size/2, y: challengeGreenBlock.y - challengeGreenBlock.size/2, width: challengeGreenBlock.size, height: challengeGreenBlock.size };
+            if (rectIntersect(rect, gr)) { levelComplete(); return true; }
+          }
+          return false;
+        }
+
+        checkCollisions(cube);
+        checkCollisions(cube2);
       }
 
       // -------------------------------------------------
@@ -5372,7 +5598,11 @@
           drawChallengeGreyBlocks();
           drawChallengeTeleportLines();
         }
-        drawCube();
+        if (levels[currentLevel].challengeTwoLevel) {
+          drawTwoCubes();
+        } else {
+          drawCube();
+        }
         drawBrownParticles();
         drawGreyParticles();
         drawLevelText();
@@ -5390,6 +5620,9 @@
           drawBulletHellBlocks();
         }
         if (levels[currentLevel].challengeDashingLevel) {
+          drawChallengeLines();
+          drawChallengeGreenBlock();
+        } else if (levels[currentLevel].challengeTwoLevel) {
           drawChallengeLines();
           drawChallengeGreenBlock();
         } else if (levels[currentLevel].challengeTeleportLevel) {


### PR DESCRIPTION
## Summary
- add new 'Challenge of 2' extra level with two small cubes
- show instructions for dual controls
- handle unique update logic and drawing for two cubes
- disable dash and use red lines

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886862e70e8832585967db33038b7fb