### PR TITLE
Add Challenge Of Two level

### DIFF
--- a/index.html
+++ b/index.html
@@ -786,6 +786,23 @@
       let spacePressTimes = [];
       let lastSpamColorChange = 0;
 
+      // Globals for Challenge of Two (extra challenge)
+      let challengeTwoPhase = 1;
+      let challengeTwoStartTime = 0;
+      let challengeTwoInfoUntil = 0;
+      let lastTwoLineSpawn = 0;
+      let lastTwoRedSpawn = 0;
+      let challengeTwoLines = [];
+      let challengeTwoReds = [];
+      let challengeTwoWhiteBlock = null;
+      let challengeTwoGreenBlock = null;
+      let cubeBlue = null;
+      let cubeYellow = null;
+      let lastDirectionBlue = null;
+      let lastDirectionYellow = null;
+      let arrowDirBlueX = 0, arrowDirBlueY = -1;
+      let arrowDirYellowX = 0, arrowDirYellowY = -1;
+
       function getRandomThreeColorSpeed() {
         const pool = [1, 2, 3, 4];
         return pool[Math.floor(Math.random() * pool.length)];
@@ -2246,6 +2263,17 @@
           challengeName: "Three Colors",
           platforms: [],
           hazards: []
+        },
+        {
+          // -------------------------------------------------
+          // EXTRA CHALLENGE: Challenge Of Two
+          // -------------------------------------------------
+          spawn: { x: 0.5, y: 0.5 },
+          challengeTwo: true,
+          stage: 4,
+          challengeName: "Challenge Of Two",
+          platforms: [],
+          hazards: []
         }
       ];
 
@@ -2479,6 +2507,24 @@
           challengePausedTime = 0;
           isChallengePaused = false;
           lastChallengePauseStart = 0;
+        } else if (lvl.challengeTwo) {
+          target = null;
+          challengeTwoPhase = 1;
+          challengeTwoStartTime = Date.now();
+          challengeTwoInfoUntil = challengeTwoStartTime + 4000;
+          lastTwoLineSpawn = challengeTwoStartTime;
+          lastTwoRedSpawn = challengeTwoStartTime;
+          challengeTwoLines = [];
+          challengeTwoReds = [];
+          challengeTwoWhiteBlock = null;
+          challengeTwoGreenBlock = null;
+          const size = cube.size / 1.3;
+          cubeBlue = { x: canvas.width * 0.45, y: canvas.height * 0.5, size, vx: 0, vy: 0 };
+          cubeYellow = { x: canvas.width * 0.55, y: canvas.height * 0.5, size, vx: 0, vy: 0 };
+          lastDirectionBlue = null;
+          lastDirectionYellow = null;
+          arrowDirBlueX = 0; arrowDirBlueY = -1;
+          arrowDirYellowX = 0; arrowDirYellowY = -1;
         } else if (lvl.level13) {
           level13Stage = 0;
           level13PillarsSpawned = false;
@@ -3110,15 +3156,35 @@
           switch (e.key) {
             case "ArrowUp":
               lastDirection = "up";
+              lastDirectionYellow = "up";
               break;
             case "ArrowDown":
               lastDirection = "down";
+              lastDirectionYellow = "down";
               break;
             case "ArrowLeft":
               lastDirection = "left";
+              lastDirectionYellow = "left";
               break;
             case "ArrowRight":
               lastDirection = "right";
+              lastDirectionYellow = "right";
+              break;
+            case "w":
+            case "W":
+              lastDirectionBlue = "up";
+              break;
+            case "s":
+            case "S":
+              lastDirectionBlue = "down";
+              break;
+            case "a":
+            case "A":
+              lastDirectionBlue = "left";
+              break;
+            case "d":
+            case "D":
+              lastDirectionBlue = "right";
               break;
           }
         }
@@ -3376,6 +3442,10 @@
       function update() {
         if (gamePaused) return;
         const now = Date.now();
+        if (levels[currentLevel].challengeTwo) {
+          updateChallengeTwo(now);
+          return;
+        }
         if (spamAbilityUnlocked) {
           spacePressTimes = spacePressTimes.filter(t => now - t <= 1000);
           spamActive = spacePressTimes.length >= 3;
@@ -4915,6 +4985,140 @@
               return;
             }
           }
+        } 
+      }
+
+      function updateChallengeTwo(now) {
+        const lineSpeed = 2;
+        const redSpeed = 2;
+
+        const cubes = [
+          { obj: cubeBlue, dir: { x: arrowDirBlueX, y: arrowDirBlueY }, color: "blue", last: lastDirectionBlue },
+          { obj: cubeYellow, dir: { x: arrowDirYellowX, y: arrowDirYellowY }, color: "yellow", last: lastDirectionYellow }
+        ];
+
+        // Movement helper
+        function moveCube(c, lastDir, dir) {
+          const acc = currentAcceleration * 0.5;
+          if (lastDir === "up") { c.vy -= acc; c.vx = 0; dir.x = 0; dir.y = -1; }
+          else if (lastDir === "down") { c.vy += acc; c.vx = 0; dir.x = 0; dir.y = 1; }
+          else if (lastDir === "left") { c.vx -= acc; c.vy = 0; dir.x = -1; dir.y = 0; }
+          else if (lastDir === "right") { c.vx += acc; c.vy = 0; dir.x = 1; dir.y = 0; }
+          c.vx *= 0.88; c.vy *= 0.88;
+          c.x += c.vx; c.y += c.vy;
+          if (c.x - c.size / 2 < 0) { c.x = c.size / 2; c.vx = 0; }
+          if (c.x + c.size / 2 > canvas.width) { c.x = canvas.width - c.size / 2; c.vx = 0; }
+          if (c.y - c.size / 2 < 0) { c.y = c.size / 2; c.vy = 0; }
+          if (c.y + c.size / 2 > canvas.height) { c.y = canvas.height - c.size / 2; c.vy = 0; }
+        }
+
+        let dirB = { x: arrowDirBlueX, y: arrowDirBlueY };
+        moveCube(cubeBlue, lastDirectionBlue, dirB);
+        arrowDirBlueX = dirB.x; arrowDirBlueY = dirB.y;
+        let dirY = { x: arrowDirYellowX, y: arrowDirYellowY };
+        moveCube(cubeYellow, lastDirectionYellow, dirY);
+        arrowDirYellowX = dirY.x; arrowDirYellowY = dirY.y;
+
+        // spawn logic
+        if (challengeTwoPhase === 1) {
+          if (now - lastTwoLineSpawn >= 3000) {
+            spawnLine();
+            lastTwoLineSpawn = now;
+          }
+          if (now - challengeTwoStartTime >= 25000 && !challengeTwoWhiteBlock) {
+            challengeTwoWhiteBlock = { x: canvas.width/2, y: canvas.height/2, size: 100 };
+          }
+        } else if (challengeTwoPhase === 2) {
+          if (now - lastTwoLineSpawn >= 2000) { spawnLine(); lastTwoLineSpawn = now; }
+          if (now - lastTwoRedSpawn >= 1000) { spawnRed(false); lastTwoRedSpawn = now; }
+          if (now - challengeTwoStartTime >= 30000 && !challengeTwoWhiteBlock) {
+            challengeTwoWhiteBlock = { x: canvas.width/2, y: canvas.height/2, size: 100 };
+          }
+        } else if (challengeTwoPhase === 3) {
+          if (now - lastTwoLineSpawn >= 1000) { spawnLine(); lastTwoLineSpawn = now; }
+          if (now - lastTwoRedSpawn >= 500) { spawnRed(true); lastTwoRedSpawn = now; }
+          if (now - challengeTwoStartTime >= 40000 && !challengeTwoGreenBlock) {
+            challengeTwoGreenBlock = { x: canvas.width/2, y: canvas.height/2, size: 200 };
+          }
+        }
+
+        // update lines
+        for (let i=challengeTwoLines.length-1;i>=0;i--) {
+          let l=challengeTwoLines[i];
+          l.x += l.vx; l.y += l.vy;
+          if (l.x > canvas.width || l.x + l.width < 0 || l.y > canvas.height || l.y + l.height < 0) {
+            challengeTwoLines.splice(i,1);
+            continue;
+          }
+        }
+        // update reds
+        for (let i=challengeTwoReds.length-1;i>=0;i--) {
+          let b=challengeTwoReds[i];
+          b.x += b.vx; b.y += b.vy;
+          if (b.x > canvas.width || b.x + b.width < 0 || b.y > canvas.height || b.y + b.height < 0) {
+            challengeTwoReds.splice(i,1); continue; }
+        }
+
+        // collision helper
+        function checkCollisions(c, color) {
+          const rect={x:c.x-c.size/2,y:c.y-c.size/2,width:c.size,height:c.size};
+          for (let i=challengeTwoLines.length-1;i>=0;i--) {
+            let l=challengeTwoLines[i];
+            let lRect={x:l.x,y:l.y,width:l.width,height:l.height};
+            if (rectIntersect(rect,lRect)) {
+              if (l.color!==color) { deathSound.currentTime=0; deathSound.play(); loadLevel(currentLevel); return true; }
+              challengeTwoLines.splice(i,1);
+            }
+          }
+          for (let b of challengeTwoReds) {
+            let rRect={x:b.x,y:b.y,width:b.width,height:b.height};
+            if (rectIntersect(rect,rRect)) { deathSound.currentTime=0; deathSound.play(); loadLevel(currentLevel); return true; }
+          }
+          if (challengeTwoWhiteBlock) {
+            let wRect={x:challengeTwoWhiteBlock.x-challengeTwoWhiteBlock.size/2,y:challengeTwoWhiteBlock.y-challengeTwoWhiteBlock.size/2,width:challengeTwoWhiteBlock.size,height:challengeTwoWhiteBlock.size};
+            if (rectIntersect(rect,wRect)) {
+              challengeTwoPhase++; challengeTwoWhiteBlock=null; challengeTwoStartTime=now; lastTwoLineSpawn=now; lastTwoRedSpawn=now; return false;
+            }
+          }
+          if (challengeTwoGreenBlock) {
+            let gRect={x:challengeTwoGreenBlock.x-challengeTwoGreenBlock.size/2,y:challengeTwoGreenBlock.y-challengeTwoGreenBlock.size/2,width:challengeTwoGreenBlock.size,height:challengeTwoGreenBlock.size};
+            if (rectIntersect(rect,gRect)) { levelComplete(); return true; }
+          }
+          return false;
+        }
+
+        if (checkCollisions(cubeBlue,"blue")) return;
+        if (checkCollisions(cubeYellow,"yellow")) return;
+
+        // spawn helpers
+        function spawnLine() {
+          const thickness=20; const horiz=Math.random()<0.5; const color=Math.random()<0.5?"blue":"yellow";
+          if (horiz) {
+            const top=Math.random()<0.5;
+            const y=top?-thickness:canvas.height;
+            const vy=top?lineSpeed:-lineSpeed;
+            challengeTwoLines.push({x:0,y,width:canvas.width,height:thickness,vx:0,vy,color});
+          } else {
+            const left=Math.random()<0.5;
+            const x=left?-thickness:canvas.width;
+            const vx=left?lineSpeed:-lineSpeed;
+            challengeTwoLines.push({x,y:0,width:thickness,height:canvas.height,vx,vy:0,color});
+          }
+        }
+        function spawnRed(full) {
+          const size=cube.size/1.3;
+          if (!full) {
+            challengeTwoReds.push({x:Math.random()*(canvas.width-size),y:-size,width:size,height:size,vx:0,vy:redSpeed});
+          } else {
+            for (let i=0;i<2;i++) {
+              let side=Math.floor(Math.random()*4); let b={width:size,height:size,vx:0,vy:0,x:0,y:0};
+              if(side===0){b.x=-size;b.y=Math.random()*(canvas.height-size);b.vx=redSpeed;}
+              else if(side===1){b.x=canvas.width;b.y=Math.random()*(canvas.height-size);b.vx=-redSpeed;}
+              else if(side===2){b.x=Math.random()*(canvas.width-size);b.y=-size;b.vy=redSpeed;}
+              else{b.x=Math.random()*(canvas.width-size);b.y=canvas.height;b.vy=-redSpeed;}
+              challengeTwoReds.push(b);
+            }
+          }
         }
       }
 
@@ -5165,6 +5369,78 @@
           );
         }
       }
+
+      function drawChallengeTwoLines() {
+        if (levels[currentLevel].challengeTwo) {
+          for (let line of challengeTwoLines) {
+            ctx.fillStyle = line.color;
+            ctx.fillRect(line.x, line.y, line.width, line.height);
+          }
+        }
+      }
+      function drawChallengeTwoReds() {
+        if (levels[currentLevel].challengeTwo) {
+          ctx.fillStyle = "red";
+          for (let b of challengeTwoReds) {
+            ctx.fillRect(b.x, b.y, b.width, b.height);
+          }
+        }
+      }
+      function drawChallengeTwoWhite() {
+        if (levels[currentLevel].challengeTwo && challengeTwoWhiteBlock) {
+          ctx.fillStyle = "white";
+          ctx.fillRect(
+            challengeTwoWhiteBlock.x - challengeTwoWhiteBlock.size / 2,
+            challengeTwoWhiteBlock.y - challengeTwoWhiteBlock.size / 2,
+            challengeTwoWhiteBlock.size,
+            challengeTwoWhiteBlock.size
+          );
+        }
+      }
+      function drawChallengeTwoGreen() {
+        if (levels[currentLevel].challengeTwo && challengeTwoGreenBlock) {
+          ctx.fillStyle = "green";
+          ctx.fillRect(
+            challengeTwoGreenBlock.x - challengeTwoGreenBlock.size / 2,
+            challengeTwoGreenBlock.y - challengeTwoGreenBlock.size / 2,
+            challengeTwoGreenBlock.size,
+            challengeTwoGreenBlock.size
+          );
+        }
+      }
+      function drawCubeGeneric(c, dirX, dirY, color) {
+        ctx.fillStyle = "#fff";
+        ctx.fillRect(c.x - c.size / 2, c.y - c.size / 2, c.size, c.size);
+        ctx.fillStyle = color;
+        let mag = Math.hypot(dirX, dirY);
+        let uX = dirX, uY = dirY;
+        if (mag === 0) { uX = 0; uY = -1; }
+        const angle = Math.atan2(uY, uX);
+        const a = c.size * 0.3;
+        const b = c.size * 0.15;
+        const cVal = c.size * 0.3;
+        function rotPt(x, y, ang) {
+          return { x: x * Math.cos(ang) - y * Math.sin(ang), y: x * Math.sin(ang) + y * Math.cos(ang) };
+        }
+        let tipLocal = { x: a, y: 0 };
+        let baseLeft = { x: -b, y: cVal };
+        let baseRight = { x: -b, y: -cVal };
+        let tipRot = rotPt(tipLocal.x, tipLocal.y, angle);
+        let blRot = rotPt(baseLeft.x, baseLeft.y, angle);
+        let brRot = rotPt(baseRight.x, baseRight.y, angle);
+        const tipX = c.x + tipRot.x;
+        const tipY = c.y + tipRot.y;
+        const blX  = c.x + blRot.x;
+        const blY  = c.y + blRot.y;
+        const brX  = c.x + brRot.x;
+        const brY  = c.y + brRot.y;
+        ctx.beginPath();
+        ctx.moveTo(tipX, tipY);
+        ctx.lineTo(blX, blY);
+        ctx.lineTo(brX, brY);
+        ctx.closePath();
+        ctx.fill();
+      }
       function drawLevelText() {
         ctx.fillStyle = "#fff";
         ctx.font = "30px sans-serif";
@@ -5196,6 +5472,13 @@
             ctx.fillText("Challenge of Colors 2/3", 10, 40);
           } else {
             ctx.fillText("Challenge Of Colors 1/3", 10, 40);
+          }
+        } else if (levels[currentLevel].challengeTwo) {
+          ctx.fillText(`Challenge Of Two ${challengeTwoPhase}/3`, 10, 40);
+          if (Date.now() < challengeTwoInfoUntil) {
+            ctx.textAlign = "center";
+            ctx.fillText("Control The Blue One with WASD, control the Yellow One with Arrow Keys", canvas.width / 2, 80);
+            ctx.textAlign = "left";
           }
         } else if (levels[currentLevel].threeColorsChallenge) {
           ctx.fillText("Three Colors", 10, 40);
@@ -5372,7 +5655,16 @@
           drawChallengeGreyBlocks();
           drawChallengeTeleportLines();
         }
-        drawCube();
+        if (levels[currentLevel].challengeTwo) {
+          drawChallengeTwoLines();
+          drawChallengeTwoReds();
+          drawCubeGeneric(cubeBlue, arrowDirBlueX, arrowDirBlueY, "blue");
+          drawCubeGeneric(cubeYellow, arrowDirYellowX, arrowDirYellowY, "yellow");
+          drawChallengeTwoWhite();
+          drawChallengeTwoGreen();
+        } else {
+          drawCube();
+        }
         drawBrownParticles();
         drawGreyParticles();
         drawLevelText();


### PR DESCRIPTION
## Summary
- add new extra challenge level: Challenge Of Two
- spawn and update two controllable cubes
- display instructions for controls and phase progress
- draw new challenge objects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886e9ec52488325808e9e10568576ac